### PR TITLE
feat: apply conditional layout padding for auth pages

### DIFF
--- a/guardians/src/App.tsx
+++ b/guardians/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
     return (
         <AuthProvider>
             {isAuthPage ? <AuthHeader /> : <Header />}
-            <div style={{ paddingTop: isAuthPage ? "0" : "5rem"}}>
+            <div style={{ paddingTop: isAuthPage ? "0" : "5rem", paddingLeft : "5rem", maxWidth : "1920px"}}>
                 <Routes>
                     <Route path="/" element={<Home />} />
 

--- a/guardians/src/App.tsx
+++ b/guardians/src/App.tsx
@@ -22,13 +22,20 @@ import PrivateRoute from "./components/PrivateRoute";
 
 function App() {
     const location = useLocation();
+
     const authPaths = ["/login", "/signup", "/signup/success", "/findPassword"];
     const isAuthPage = authPaths.includes(location.pathname);
 
     return (
         <AuthProvider>
             {isAuthPage ? <AuthHeader /> : <Header />}
-            <div style={{ paddingTop: isAuthPage ? "0" : "5rem", paddingLeft : "5rem", maxWidth : "1920px"}}>
+            <div
+                style={{
+                    paddingTop: isAuthPage ? "0" : "5rem",
+                    paddingLeft: isAuthPage ? "0" : "5rem",
+                    maxWidth: "100%",
+                }}
+            >
                 <Routes>
                     <Route path="/" element={<Home />} />
 
@@ -65,7 +72,7 @@ function App() {
                             </PublicOnlyRoute>
                         }
                     />
-                    {/* 로그인한 사람만 들어올 수 있음 */}
+
                     <Route
                         path="/dashboard"
                         element={
@@ -83,7 +90,6 @@ function App() {
                         }
                     />
 
-                    {/* 자유 접근 가능 */}
                     <Route path="/ranking" element={<RankingPage />} />
                     <Route path="/wargame" element={<WargamePage />} />
 

--- a/guardians/src/components/AuthHeader.module.css
+++ b/guardians/src/components/AuthHeader.module.css
@@ -12,7 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-width: 1920px;
+    max-width: 100%;
     padding: 1rem 2rem;
     margin: 0 auto;
 }

--- a/guardians/src/components/AuthHeader.module.css
+++ b/guardians/src/components/AuthHeader.module.css
@@ -12,7 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-width: 1440px;
+    max-width: 1920px;
     padding: 1rem 2rem;
     margin: 0 auto;
 }
@@ -26,7 +26,7 @@
 }
 
 .logo {
-    font-size: 1.7rem;
+    font-size: 2rem;
     font-weight: bold;
     color: white;
     text-decoration: none;

--- a/guardians/src/components/Header.module.css
+++ b/guardians/src/components/Header.module.css
@@ -14,7 +14,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-width: 1440px;
+    max-width: 1920px;
     padding: 1rem 2rem;
     margin: 0 auto;
 }
@@ -28,7 +28,7 @@
 }
 
 .logo {
-    font-size: 1.7rem;
+    font-size: 2rem;
     font-weight: bold;
     color: orange;
     text-decoration: none;
@@ -54,8 +54,9 @@
 
 /* ===== 메뉴 ===== */
 .nav {
+    font-size: 1.1rem;
     display: flex;
-    gap: 2rem;
+    gap: 2.5rem;
     margin-left: 2rem;
 }
 
@@ -79,7 +80,7 @@
 .loginButton {
     padding: 0.5rem 1rem;
     border: 1px solid lightgray;
-    font-size: 0.9rem;
+    font-size: 1rem;
     border-radius: 5px;
     background: white;
     cursor: pointer;

--- a/guardians/src/components/Header.module.css
+++ b/guardians/src/components/Header.module.css
@@ -14,7 +14,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-width: 1920px;
+    max-width: 100%;
     padding: 1rem 2rem;
     margin: 0 auto;
 }

--- a/guardians/src/pages/HomePage/Home.tsx
+++ b/guardians/src/pages/HomePage/Home.tsx
@@ -1,30 +1,28 @@
 function Home() {
     return (
-        <div style={{ padding: "0", margin: "0" }}>
+        <div style={{ padding: "0", margin: "0", maxWidth: "1920px", marginLeft: "-5rem"}}>
             {/* 배경색이 전체 너비로 적용되는 상단 Hero 영역 */}
             <div
                 style={{
                     backgroundColor: "#f9c37b",
-                    paddingTop: 80,              // 상단 여백 제거
-                    paddingBottom: "13rem",    // 하단만 여백 유지
-                    marginTop: "-6rem",        // ❗ 강제 상단 여백 제거 (부모 여백 무력화용)
+                    paddingTop: "8rem",
+                    paddingBottom: "13rem",
+                    marginTop: "-6rem",
                     color: "#000",
-                    width: "100vw",            // 전체 너비 강제 적용
+                    width: "100%",
                     height: "30vh",
-                    position: "relative",
-                    left: "calc(-100vw + 100%)", // 중앙 기준으로 왼쪽 이동
                 }}
             >
                 {/* 상단 제목 영역 */}
                 <h1
                     style={{
-                        color : "white",
-                        fontSize: "4.5rem",        // 큰 글씨
-                        fontWeight: "bold",        // 굵은 텍스트
+                        color: "white",
+                        fontSize: "4.5rem",
+                        fontWeight: "bold",
                         marginTop: "6rem",
-                        marginBottom: "1rem",      // 아래쪽 간격
-                        marginLeft: "5rem"
-                }}
+                        marginBottom: "1rem",
+                        marginLeft: "5rem",
+                    }}
                 >
                     모의해킹플랫폼 <br />
                     <span style={{ fontWeight: "400" }}>
@@ -35,27 +33,25 @@ function Home() {
                 {/* 설명 문구 영역 */}
                 <p
                     style={{
-                        fontSize: "2rem",        // 중간 크기 텍스트
-                        color: "#555",             // 회색 계열 텍스트
-                        marginTop: "2rem",         // 위쪽 간격
-                        marginLeft: "5rem"
-                }}
+                        fontSize: "2rem",
+                        color: "#555",
+                        marginTop: "2rem",
+                        marginLeft: "5rem",
+                    }}
                 >
                     배우고, 도전하고, 성장하세요. <br />
                     <span
                         style={{
-                            color: "#9c5e25",       // 갈색 계열 강조
-                            fontWeight: 600,        // 강조 굵기
+                            color: "#9c5e25",
+                            fontWeight: 600,
                         }}
                     >
                         당신의 실력을 수호하는 공간, Guardians.
                     </span>
                 </p>
-
-
             </div>
         </div>
-            );
+    );
 }
 
 export default Home;

--- a/guardians/src/pages/HomePage/Home.tsx
+++ b/guardians/src/pages/HomePage/Home.tsx
@@ -1,6 +1,6 @@
 function Home() {
     return (
-        <div style={{ padding: "0", margin: "0", maxWidth: "1920px", marginLeft: "-5rem"}}>
+        <div style={{ padding: "0", margin: "0", maxWidth: "100vw", marginLeft: "-5rem"}}>
             {/* 배경색이 전체 너비로 적용되는 상단 Hero 영역 */}
             <div
                 style={{

--- a/guardians/src/pages/LoginPage/Login.module.css
+++ b/guardians/src/pages/LoginPage/Login.module.css
@@ -156,7 +156,8 @@ body {
 .container {
     display: flex;
     height: 100vh;
-    width: 100vw;
+    width: 100%;
+    overflow: hidden;
 }
 
 /* 왼쪽 영역 */

--- a/guardians/src/pages/WargamePage/PopularWargameList.tsx
+++ b/guardians/src/pages/WargamePage/PopularWargameList.tsx
@@ -19,6 +19,7 @@ function PopularWargameList() {
     return (
         <div
             style={{
+                width: "330px",
                 marginTop: "1rem",
                 backgroundColor: "#fff",
                 borderRadius: "1rem",

--- a/guardians/src/pages/WargamePage/ProfileCard.tsx
+++ b/guardians/src/pages/WargamePage/ProfileCard.tsx
@@ -2,7 +2,7 @@ function UserInfoCard() {
     return (
         <div
             style={{
-                width: "320px",
+                width: "360px",
                 border: "1px solid #ccc",
                 borderRadius: "10px",
                 overflow: "hidden",


### PR DESCRIPTION
## 📌 PR 제목
- feat: apply conditional layout padding for auth pages

---

## ✨ 주요 변경사항
- 로그인/회원가입/비밀번호 찾기 등 인증 페이지에서는 `App.tsx` 내 padding 제거
- 그 외 일반 페이지는 기존처럼 `padding-left: 5rem`, `padding-top: 5rem` 유지
- 인증 페이지에서는 `AuthHeader`를, 나머지 페이지에서는 `Header`를 조건부 렌더링

---

## 🔍 상세 설명
- 인증 페이지에서 레이아웃이 불필요하게 밀리는 문제를 해결하기 위함
- `useLocation()`으로 현재 경로를 판단하여 `isAuthPage` 조건 분기
- 인증 페이지는 `padding: 0`을 적용해 전체 화면을 꽉 채우도록 수정
- CSS에서 억지로 `margin-left: -5rem` 등으로 밀던 비정상적인 구조 제거 가능해짐

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 인증 관련 페이지에서 padding이 적용되지 않는지 확인
- [x] 일반 페이지에서는 padding 정상 적용 여부 확인
- [x] Header가 정상적으로 조건 분기되어 렌더링되는지 확인
- [x] 불필요한 margin/padding 조작 CSS 제거 가능 확인

---

## 🧪 테스트 결과
- [x] `/login`, `/signup`, `/findPassword`, `/signup/success` → 전체화면으로 잘림 없이 렌더링됨
- [x] `/`, `/dashboard`, `/community/*`, `/ranking` 등 → 기존대로 좌측 padding 유지됨
- [x] 직접 브라우저에서 시각적으로 확인 완료

---

## 📎 관련 이슈
Closes #이슈번호 (해당 사항 있을 경우 기입)

---

## 💬 기타 공유사항
- 로그인/회원가입 등에서 쓰던 CSS 내 `margin-left: -5rem`은 제거해도 됨
- 이후 `/login`이나 `/signup` 경로가 더 추가된다면 `authPaths` 배열만 수정하면 됨
- 레이아웃 관련 처리용 `Layout` 컴포넌트를 따로 분리하는 것도 고려 가능
