### PR TITLE
feat: add conditional layout padding for auth pages and adjust headers

### DIFF
--- a/guardians/src/pages/LoginPage/FindPassword.module.css
+++ b/guardians/src/pages/LoginPage/FindPassword.module.css
@@ -125,7 +125,7 @@
     font-size: 1.6rem;
     line-height: 0.7rem;
     max-width: 500px;
-    font-weight: 600;
+    font-weight: 500;
 }
 
 .visual {

--- a/guardians/src/pages/LoginPage/FindPassword.tsx
+++ b/guardians/src/pages/LoginPage/FindPassword.tsx
@@ -58,7 +58,8 @@ const FindPassword = () => {
             <div className={styles.left}>
                 <div className={styles.textBox}>
                     <p>환영합니다,</p>
-                    성장을 위한 발걸음 <strong style={{fontSize:"2.1rem", color: "white" }}>Guardians</strong> 입니다.
+                    <span style={{ fontWeight: "750", color: "#fff" }}>모의 해킹</span> 성장을 위한 발걸음{" "}
+                    <strong style={{ fontSize: "2.1rem", color: "white" }}>가디언즈</strong> 입니다.
                 </div>
                 <img src="/login_logo.png" alt="login visual" className={styles.visual} />
             </div>

--- a/guardians/src/pages/LoginPage/Login.module.css
+++ b/guardians/src/pages/LoginPage/Login.module.css
@@ -191,7 +191,7 @@ body {
     font-size: 1.6rem;
     line-height: 0.7rem;
     max-width: 500px;
-    font-weight: 600;
+    font-weight: 500;
 }
 
 

--- a/guardians/src/pages/LoginPage/Login.tsx
+++ b/guardians/src/pages/LoginPage/Login.tsx
@@ -44,7 +44,8 @@ const Login = () => {
             <div className={styles.left}>
                 <div className={styles.textBox}>
                     <p>환영합니다,</p>
-                    성장을 위한 발걸음 <strong style={{fontSize:"2.1rem", color: "white" }}>Guardians</strong> 입니다.
+                    <span style={{ fontWeight: "750", color: "#fff" }}>모의 해킹</span> 성장을 위한 발걸음{" "}
+                    <strong style={{ fontSize: "2.1rem", color: "white" }}>가디언즈</strong> 입니다.
                 </div>
                 <img src="/login_logo.png" alt="login visual" className={styles.visual} />
             </div>

--- a/guardians/src/pages/LoginPage/Signup.module.css
+++ b/guardians/src/pages/LoginPage/Signup.module.css
@@ -26,7 +26,7 @@ body {
     font-size: 1.6rem;
     line-height: 0.7rem;
     max-width: 500px;
-    font-weight: 600;
+    font-weight: 500;
 }
 
 .visual {

--- a/guardians/src/pages/LoginPage/Signup.tsx
+++ b/guardians/src/pages/LoginPage/Signup.tsx
@@ -90,7 +90,8 @@ const Signup = () => {
             <div className={styles.left}>
                 <div className={styles.textBox}>
                     <p>환영합니다,</p>
-                    성장을 위한 발걸음 <strong style={{ fontSize: "2.1rem", color: "white" }}>Guardians</strong> 입니다.
+                    <span style={{ fontWeight: "750", color: "#fff" }}>모의 해킹</span> 성장을 위한 발걸음{" "}
+                    <strong style={{ fontSize: "2.1rem", color: "white" }}>가디언즈</strong> 입니다.
                 </div>
                 <img src="/login_logo.png" alt="login visual" className={styles.visual} />
             </div>

--- a/guardians/src/pages/LoginPage/SignupSuccess.module.css
+++ b/guardians/src/pages/LoginPage/SignupSuccess.module.css
@@ -38,7 +38,7 @@
 
 .loginButton {
     padding: 0.9rem 2rem;
-    background-color: #535bf2;
+    background-color: #FF8C1A;
     color: white;
     font-size: 1rem;
     font-weight: 600;
@@ -49,5 +49,5 @@
 }
 
 .loginButton:hover {
-    background-color: #3f46c2;
+    background-color: #FFA94D;
 }


### PR DESCRIPTION
## 📌 PR 제목
- feat: add conditional layout padding and header switching for auth pages

---

## ✨ 주요 변경사항
- App.tsx에서 인증 관련 페이지(`/login`, `/signup`, `/signup/success`, `/findPassword`)에만 `padding` 제거하도록 분기 처리
- 인증 페이지에서는 `AuthHeader`, 나머지 페이지에서는 `Header` 컴포넌트를 사용
- Home 페이지는 padding을 유지하도록 예외 처리

---

## 🔍 상세 설명
- 인증 관련 페이지에서는 전체 화면을 꽉 채우는 UI가 필요하지만, App.tsx의 공통 padding 때문에 화면이 밀리는 문제가 있었음
- 이를 해결하기 위해 `useLocation()`으로 현재 경로를 판단해 인증 관련 경로일 경우 padding을 제거
- 동시에 헤더도 `AuthHeader`와 일반 `Header`로 조건부 렌더링하여 UI 일관성 확보
- Home 페이지는 로그인 이후 첫 진입 지점이기 때문에 padding을 유지하여 레이아웃 통일감을 줌

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 인증 페이지에서 padding이 적용되지 않는지 확인
- [x] 일반 페이지에서 기존 padding 유지되는지 확인
- [x] `AuthHeader`와 `Header`가 올바르게 렌더링되는지 확인
- [x] 불필요한 CSS 트릭(margin-left: -5rem 등) 제거 가능 상태 확인

---

## 🧪 테스트 결과
- [x] `/login`, `/signup`, `/findPassword`, `/signup/success` 페이지에서 전체 화면 UI 확인
- [x] `/`, `/dashboard`, `/community/*`, `/ranking` 페이지에서 기존 레이아웃 정상 유지
- [x] 로그인/로그아웃 후 페이지 이동 시 UI 충돌 없음

---

## 📎 관련 이슈
Closes #이슈번호 (예: `Closes #42`)

---

## 💬 기타 공유사항
- `/signup/success` 페이지 진입이 로그인 상태일 경우 막혀있어 개발 테스트에 어려움이 있었음
- 개발 시 테스트를 위한 임시 bypass 방법(localStorage 초기화, AuthContext 우회 등) 고려
- 이후 레이아웃 구조를 좀 더 명확히 하기 위해 Layout 컴포넌트 분리도 계획 중
