### PR TITLE
feat: add error modal for login/signup and improve UX

### DIFF
--- a/guardians/src/pages/ErrorModal/ErrorModal.tsx
+++ b/guardians/src/pages/ErrorModal/ErrorModal.tsx
@@ -1,0 +1,60 @@
+interface ErrorModalProps {
+    message: string;
+    onClose: () => void;
+}
+
+const ErrorModal = ({ message, onClose }: ErrorModalProps) => {
+    return (
+        <div
+            style={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: "rgba(0,0,0,0.5)",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                zIndex: 9999
+            }}
+        >
+            <div
+                style={{
+                    background: "white",
+                    padding: "2rem",
+                    borderRadius: "1rem",
+                    minWidth: "300px",
+                    textAlign: "center",
+                    boxShadow: "0 4px 20px rgba(0,0,0,0.1)"
+                }}
+            >
+                <p style={{ marginBottom: "1.5rem", fontWeight: 600 }}>{message}</p>
+                <button
+                    onClick={onClose}
+                    style={{
+                        backgroundColor: "#FFA94D",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "0.5rem",
+                        padding: "0.6rem 1.5rem",
+                        fontWeight: 600,
+                        cursor: "pointer",
+                        fontSize: "1rem",
+                        transition: "background-color 0.25s ease"
+                    }}
+                    onMouseEnter={(e) => {
+                        (e.target as HTMLButtonElement).style.backgroundColor = "#ff9b30";
+                    }}
+                    onMouseLeave={(e) => {
+                        (e.target as HTMLButtonElement).style.backgroundColor = "#FFA94D";
+                    }}
+                >
+                    확인
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ErrorModal;

--- a/guardians/src/pages/LoginPage/Login.tsx
+++ b/guardians/src/pages/LoginPage/Login.tsx
@@ -1,20 +1,30 @@
-import {useState} from "react";
-import {useNavigate} from "react-router-dom";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 import styles from "./Login.module.css";
 import emailIcon from "../../assets/mail.png";
 import lockIcon from "../../assets/lock.png";
-import {useAuth} from "../../context/AuthContext";
+import { useAuth } from "../../context/AuthContext";
+import ErrorModal from "../ErrorModal/ErrorModal"; // ✅ 경로 확인!
 
 const Login = () => {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [errorMsg, setErrorMsg] = useState("");
+    const [showModal, setShowModal] = useState(false);
+
     const navigate = useNavigate();
-    const {login} = useAuth();
+    const { login } = useAuth();
     const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
     const handleLogin = async () => {
+        if (!email.trim() || !password.trim()) {
+            setErrorMsg("이메일과 비밀번호를 모두 입력해주세요.");
+            setShowModal(true);
+            return;
+        }
+
         try {
             const res = await axios.post(
                 `${API_BASE}/api/users/login`,
@@ -26,10 +36,11 @@ const Login = () => {
             window.location.href = "/";
         } catch (err: unknown) {
             if (axios.isAxiosError(err)) {
-                alert("로그인 실패: " + (err.response?.data?.message || "에러 발생"));
+                setErrorMsg(err.response?.data?.message || "로그인 실패");
             } else {
-                alert("알 수 없는 오류가 발생했습니다");
+                setErrorMsg("알 수 없는 오류가 발생했습니다.");
             }
+            setShowModal(true);
         }
     };
 
@@ -54,7 +65,7 @@ const Login = () => {
                     <h2 className={styles.title}>가디언즈 로그인</h2>
                     <div className={styles.inputSection}>
                         <div className={styles.inputGroup}>
-                            <img src={emailIcon} alt="email"/>
+                            <img src={emailIcon} alt="email" />
                             <input
                                 type="email"
                                 placeholder="이메일을 입력해 주세요"
@@ -64,7 +75,7 @@ const Login = () => {
                             />
                         </div>
                         <div className={styles.inputGroup}>
-                            <img src={lockIcon} alt="lock"/>
+                            <img src={lockIcon} alt="lock" />
                             <input
                                 type="password"
                                 placeholder="비밀번호를 입력해 주세요"
@@ -85,6 +96,8 @@ const Login = () => {
                     </div>
                 </div>
             </div>
+
+            {showModal && <ErrorModal message={errorMsg} onClose={() => setShowModal(false)} />}
         </div>
     );
 };


### PR DESCRIPTION
## 📌 PR 제목
- feat: 로그인/회원가입 오류 모달 적용 및 UX 개선

---

## ✨ 주요 변경사항
- 공통 에러 모달 컴포넌트 `ErrorModal` 생성 및 디자인 적용
- 기존 `alert()` 사용 부분을 모두 모달로 교체 (로그인/회원가입)
- 이메일 인증 요청 시 이메일 형식 유효성 검사 추가
- 인증 코드 전송 성공, 인증 완료 시에도 모달로 안내 추가
- 인증 완료 시 이메일 입력 필드 회색 처리 및 수정 불가 상태로 변경

---

## 🔍 상세 설명
- 기존 `alert()` 기반 UX는 사용성 저하 및 일관성 부족 문제가 있었음
- 모달을 통해 사용자가 집중된 상태에서 오류 메시지를 확인할 수 있게 개선
- 이메일 형식 유효성 검사를 추가하여 불필요한 API 호출 방지
- 인증 완료 후 이메일 수정 불가 처리를 통해 보안 및 UX 향상

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] 브라우저에서 UI 테스트 완료
- [x] 백엔드 API 연동 확인
- [ ] 유닛/통합 테스트 포함 (현재는 수동 테스트로 처리)

---

## 📎 관련 이슈
Closes # (필요 시 작성)

---

## 💬 기타 공유사항
- 추후 회원가입 외 다른 페이지에서도 `ErrorModal` 공통 적용 예정
- 모달에 에러/성공 타입별 색상 또는 애니메이션 추가 고려 중
