### PR TITLE
feat: display Q&A section under wargame detail with clickable questio…

### DIFF
--- a/guardians/src/context/AuthContext.tsx
+++ b/guardians/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
-// context/AuthContext.tsx
 import axios from "axios";
 import { createContext, useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 type User = {
     id: number;
@@ -21,6 +21,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const API_BASE = import.meta.env.VITE_API_BASE_URL;
+    const navigate = useNavigate(); // ✅ 새로고침 없이 페이지 이동
 
     const login = (userData: User) => {
         console.log("📌 login() 호출됨", userData);
@@ -29,16 +30,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
     const logout = async () => {
         try {
-            setIsLoading(true); // 로딩 시작
+            setIsLoading(true);
             await axios.post(`${API_BASE}/api/users/logout`, {}, { withCredentials: true });
-            window.location.href = "/";
+            setUser(null); // ✅ 유저 상태 날림
+            navigate("/"); // ✅ 새로고침 없이 이동
         } catch (err) {
             console.error("로그아웃 실패", err);
         } finally {
             setIsLoading(false);
         }
     };
-
 
     useEffect(() => {
         axios
@@ -59,7 +60,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
                 setUser(null);
             })
             .finally(() => {
-                setIsLoading(false); // ✅ 마지막에 로딩 끝 표시
+                setIsLoading(false); // ✅ 로딩 끝
             });
     }, []);
 

--- a/guardians/src/pages/WargamePage/FilterBar.tsx
+++ b/guardians/src/pages/WargamePage/FilterBar.tsx
@@ -10,9 +10,9 @@ const categoryOptions = [
 ];
 
 const levelOptions = [
-    { value: "쉬움", label: "쉬움" },
-    { value: "보통", label: "보통" },
-    { value: "어려움", label: "어려움" },
+    { value: "EASY", label: "쉬움" },
+    { value: "MEDIUM", label: "보통" },
+    { value: "HARD", label: "어려움" },
 ];
 
 const statusOptions = [

--- a/guardians/src/pages/WargamePage/QACard.module.css
+++ b/guardians/src/pages/WargamePage/QACard.module.css
@@ -1,0 +1,82 @@
+.card {
+    background-color: #fff;
+    padding: 1.5rem;
+    border-radius: 12px;
+    border: 1px solid #eee;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
+    cursor: pointer;
+    transition: box-shadow 0.2s;
+    font-size: 0.95rem;
+}
+
+.topRow {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    margin-bottom: 0.4rem;
+    color: #888;
+}
+
+.wargameTitle {
+    font-weight: 500;
+    color: #666;
+}
+
+.userMeta {
+    color: #666;
+}
+
+.title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0.4rem 0 0.7rem;
+    line-height: 1.4;
+    color: #111;
+}
+
+.content {
+    font-size: 0.9rem;
+    color: #444;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+}
+
+.separator {
+    border: none;
+    border-top: 1px solid #eee;
+    margin: 0.5rem 0 1rem;
+}
+
+.bottomRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.iconRow {
+    display: flex;
+    gap: 1.25rem;
+    font-size: 0.85rem;
+    color: #555;
+}
+
+.iconItem {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.iconItem img {
+    width: 16px;
+    height: 16px;
+}
+
+.answeredBadge {
+    background-color: #D3F9D8;
+    color: #2B8A3E;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+}

--- a/guardians/src/pages/WargamePage/QACard.tsx
+++ b/guardians/src/pages/WargamePage/QACard.tsx
@@ -1,0 +1,72 @@
+import styles from "./QACard.module.css";
+import viewIcon from "../../assets/view.png";
+import likeIcon from "../../assets/like.png";
+import commentIcon from "../../assets/comment.png";
+import { useNavigate } from "react-router-dom";
+
+type QACardProps = {
+    question: {
+        id: number;
+        wargameTitle: string;
+        title: string;
+        content: string;
+        username: string;
+        createdAt: string;
+        answerCount: number;
+        likeCount: number;
+        viewCount: number;
+    };
+    isAnswered: boolean;
+};
+
+function QACard({ question, isAnswered }: QACardProps) {
+    const navigate = useNavigate();
+
+    return (
+        <div
+            className={styles.card}
+            onClick={() => navigate(`/qna/questions/${question.id}`)}
+            onMouseOver={(e) => (e.currentTarget.style.boxShadow = "0 6px 16px rgba(0,0,0,0.1)")}
+            onMouseOut={(e) => (e.currentTarget.style.boxShadow = "0 4px 10px rgba(0, 0, 0, 0.04)")}
+        >
+            <div className={styles.topRow}>
+                <span className={styles.wargameTitle}>워게임 {question.wargameTitle}</span>
+                <span className={styles.userMeta}>
+                    {question.username} · {question.createdAt.split("T")[0]}
+                </span>
+            </div>
+
+            <div className={styles.title}>{question.title}</div>
+            <div className={styles.content}>
+                {question.content.length > 150
+                    ? question.content.slice(0, 150) + "..."
+                    : question.content}
+            </div>
+
+            <hr className={styles.separator} />
+
+            <div className={styles.bottomRow}>
+                <div className={styles.iconRow}>
+                    <div className={styles.iconItem}>
+                        <img src={commentIcon} alt="comment" />
+                        <span>{question.answerCount} 답변</span>
+                    </div>
+                    <div className={styles.iconItem}>
+                        <img src={likeIcon} alt="like" />
+                        <span>{question.likeCount} 추천</span>
+                    </div>
+                    <div className={styles.iconItem}>
+                        <img src={viewIcon} alt="view" />
+                        <span>{question.viewCount} 조회</span>
+                    </div>
+                </div>
+
+                {isAnswered && (
+                    <span className={styles.answeredBadge}>답변 완료</span>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default QACard;

--- a/guardians/src/pages/WargamePage/WargameDetailPage.module.css
+++ b/guardians/src/pages/WargamePage/WargameDetailPage.module.css
@@ -1,0 +1,221 @@
+.container {
+    padding: 4rem 6rem;
+    font-family: 'Pretendard', sans-serif;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.header-card {
+    position: relative;
+    background-color: #fff4e6;
+    border: 1px solid #ffc078;
+    padding: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-radius: 1.25rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 0;
+}
+
+.badge {
+    background-color: #0c8;
+    color: #fff;
+    padding: 0.45rem 1rem;
+    font-size: 0.85rem;
+    border-radius: 999px;
+    font-weight: 500;
+}
+
+.meta {
+    color: #555;
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    font-size: 0.95rem;
+}
+
+.action-box {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.action-btn {
+    font-size: 0.8rem;
+    background-color: #fff;
+    border: 2px solid #ccc;
+    padding: 0.45rem 1rem;
+    border-radius: 9px;
+    cursor: pointer;
+    font-weight: 500;
+    margin-bottom: 2rem;
+}
+
+.action-btn.active {
+    border-color: #FFA94D;
+    color: #FFA94D;
+}
+
+.download-box {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1.5rem;
+    margin-right: 1rem;
+}
+
+.file-link {
+    color: #FFA94D;
+    text-decoration: none;
+    font-weight: 600;
+    border-bottom: 1px solid #FFA94D;
+}
+
+.desc-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    border-bottom: 2px solid #ffa94d;
+    padding-bottom: 0.4rem;
+    color: #333;
+}
+
+.desc {
+    background-color: #fffefc;
+    padding: 1.25rem;
+    font-size: 1rem;
+    line-height: 1.75;
+    white-space: pre-line;
+    border-radius: 0.75rem;
+    border: 1px solid #ffe0b3;
+    margin-bottom: 2rem;
+}
+
+.submit-box {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.input {
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid #ccc;
+    width: 320px;
+}
+
+.submit-btn {
+    background-color: #FFA94D;
+    border: none;
+    padding: 0.7rem 1.1rem;
+    border-radius: 0.5rem;
+    color: #fff;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-box {
+    background-color: white;
+    padding: 2rem;
+    border-radius: 1rem;
+    border: 2px solid #ccc;
+    text-align: center;
+    width: 320px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.modal-box.correct {
+    border-color: #0c8;
+}
+
+.modal-box.wrong {
+    border-color: #f03e3e;
+}
+.badge-row {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0 1rem 0;
+}
+
+.info-badge {
+    background-color: white;
+    border : solid 1px #ccc;
+    color: #664d03;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    border-radius: 999px;
+}
+.action-btn:hover {
+    border-color: #FFA94D;
+    background-color: #fff7ed; /* 연한 주황 배경 */
+    transition: all 0.2s ease-in-out;
+}
+
+.file-link:hover {
+    color: #FFA94D;
+    background-color: #fff7ed;
+    transition: all 0.2s ease-in-out;
+}
+.badge-meta-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
+}
+.qa-section {
+    margin-top: 5rem;
+}
+
+.qa-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    border-bottom: 2px solid #ffa94d;
+    padding-bottom: 0.4rem;
+    color: #333;
+}
+
+.qa-card {
+    background-color: #fffefc;
+    border: 1px solid #ffe0b3;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.qa-question {
+    color: #333;
+    margin-bottom: 0.5rem;
+}
+
+.qa-answer {
+    color: #555;
+}

--- a/guardians/src/pages/WargamePage/WargameDetailPage.tsx
+++ b/guardians/src/pages/WargamePage/WargameDetailPage.tsx
@@ -1,93 +1,227 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
+import axios from "axios";
+import styles from "./WargameDetailPage.module.css";
+import QACard from "./QACard";
+
+axios.defaults.withCredentials = true;
 
 type Wargame = {
-    id: string | undefined;
+    id: number;
     title: string;
-    category: string;
+    description: string;
+    fileUrl: string;
+    likeCount: number;
+    category: number;
     difficulty: string;
     createdAt: string;
-    description: string;
+    updatedAt: string;
+    solved: boolean;
+    bookmarked: boolean;
+    liked: boolean;
+};
+
+type QuestionWithAnswers = {
+    id: number;
+    title: string;
+    content: string;
+    username: string;
+    userId: number;
+    createdAt: string;
+    answers: {
+        id: number;
+        content: string;
+        username: string;
+        createdAt: string;
+    }[];
 };
 
 function WargameDetailPage() {
     const { id } = useParams();
     const [wargame, setWargame] = useState<Wargame | null>(null);
     const [flag, setFlag] = useState("");
+    const [qaList, setQaList] = useState<QuestionWithAnswers[]>([]);
+    const [sessionUserId, setSessionUserId] = useState<number | null>(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [modalResult, setModalResult] = useState<null | { correct: boolean; message: string }>(null);
 
-    useEffect(() => {
-        // 가라데이터 세팅
-        const mockData: Wargame = {
-            id,
-            title: "🔐 SQL Injection 초급",
-            category: "Web",
-            difficulty: "Easy",
-            createdAt: "2025-05-01",
-            description:
-                "로그인 페이지에 SQL 인젝션 취약점이 존재합니다.\n관리자 권한으로 로그인해보세요!\n\n예시: `' OR '1'='1`",
-        };
-        setWargame(mockData);
-    }, [id]);
+    const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
-    const submitFlag = () => {
-        if (flag === "FLAG{sql_injection_success}") {
-            alert("✅ 정답입니다! 고생했어요~");
-        } else {
-            alert("❌ 틀렸습니다! 다시 도전해보세요!");
+    const categoryMap: Record<number, string> = {
+        1: "웹",
+        2: "리버싱",
+        3: "포렌식",
+        4: "암호",
+        5: "시스템",
+    };
+
+    const fetchWargame = () => {
+        axios.get(`${API_BASE}/api/wargames/${id}`)
+            .then((res) => setWargame(res.data.result.data))
+            .catch((err) => console.error("워게임 상세 불러오기 실패", err));
+    };
+
+    const fetchSessionUser = async () => {
+        try {
+            const res = await axios.get(`${API_BASE}/api/users/me`);
+            setSessionUserId(res.data.result.data.id);
+        } catch {
+            setSessionUserId(null);
         }
     };
 
-    if (!wargame) return <p>로딩 중...</p>;
+    const fetchQnA = async () => {
+        try {
+            const res = await axios.get(`${API_BASE}/api/qna/wargames/${id}/questions`);
+            const questionList: QuestionWithAnswers[] = res.data.result.data;
+
+            const fullList: QuestionWithAnswers[] = await Promise.all(
+                questionList.map(async (q) => {
+                    const answerRes = await axios.get(`${API_BASE}/api/qna/answers/${q.id}`);
+                    return {
+                        ...q,
+                        answers: answerRes.data.result.data,
+                    };
+                })
+            );
+
+            setQaList(fullList);
+        } catch (e) {
+            console.error("QnA 불러오기 실패", e);
+        }
+    };
+
+    useEffect(() => {
+        fetchWargame();
+        fetchSessionUser();
+        fetchQnA();
+    }, [id]);
+
+    const submitFlag = () => {
+        axios.post(`${API_BASE}/api/wargames/${id}/submit`, { flag })
+            .then((res) => {
+                const result = res.data.result.data;
+                setModalResult(result);
+                setIsModalOpen(true);
+                fetchWargame();
+            })
+            .catch((err) => {
+                const errorMessage = err?.response?.data?.message || "서버 오류! 나중에 다시 시도해주세요.";
+                setModalResult({ correct: false, message: errorMessage });
+                setIsModalOpen(true);
+            });
+    };
+
+    const toggleBookmark = () => {
+        axios.post(`${API_BASE}/api/wargames/${id}/bookmark`).then(fetchWargame);
+    };
+
+    const toggleLike = () => {
+        axios.post(`${API_BASE}/api/wargames/${id}/like`).then(fetchWargame);
+    };
+
+    const handleCloseModal = () => {
+        setIsModalOpen(false);
+        if (modalResult?.message === "로그인이 되지 않았습니다. 로그인을 해주세요.") {
+            window.location.href = "/login";
+        } else {
+            window.location.reload();
+        }
+    };
+
+    if (!wargame) return <p style={{ padding: "3rem" }}>로딩 중...</p>;
 
     return (
-        <div style={{ padding: "3rem 10rem", fontFamily: "Pretendard, sans-serif" }}>
-            <h1 style={{ fontWeight: 700 }}>{wargame.title}</h1>
-            <div style={{ color: "#999", marginBottom: "1rem" }}>
-                카테고리: {wargame.category} | 난이도: {wargame.difficulty} | 작성일: {wargame.createdAt}
+        <div className={styles.container}>
+            <div className={styles["header-card"]}>
+                <div className={styles["title-row"]}>
+                    <h1 className={styles.title}>
+                        [{wargame.title}]
+                        {wargame.solved && <span className={styles.badge}>✔ 해결됨</span>}
+                    </h1>
+                    <div className={styles["action-box"]}>
+                        <button onClick={toggleBookmark} className={`${styles["action-btn"]} ${wargame.bookmarked ? styles.active : ""}`}>
+                            {wargame.bookmarked ? "⭐" : "☆"} 북마크
+                        </button>
+                        <button onClick={toggleLike} className={`${styles["action-btn"]} ${wargame.liked ? styles.active : ""}`}>
+                            {wargame.liked ? "❤️" : "🤍"} {wargame.likeCount}
+                        </button>
+                    </div>
+                </div>
+
+                <div className={styles["badge-meta-wrapper"]}>
+                    <div className={styles["badge-row"]}>
+                        <span className={styles["info-badge"]}>📁 {categoryMap[wargame.category]}</span>
+                        <span className={styles["info-badge"]}>🔥 {wargame.difficulty}</span>
+                    </div>
+                    <div className={styles.meta}>
+                        <span>🕒 {wargame.createdAt.split("T")[0]}</span>
+                    </div>
+                </div>
             </div>
 
-            <div
-                style={{
-                    backgroundColor: "#f9f9f9",
-                    padding: "1.5rem",
-                    borderRadius: "0.75rem",
-                    border: "1px solid #ddd",
-                    marginBottom: "2rem",
-                    lineHeight: "1.75rem",
-                    whiteSpace: "pre-line",
-                }}
-            >
-                {wargame.description}
+            <div className={styles["download-box"]}>
+                <a href={wargame.fileUrl} target="_blank" rel="noreferrer" className={styles["file-link"]}>
+                    📦 문제 파일 다운로드
+                </a>
             </div>
 
-            <div>
+            <h2 className={styles["desc-title"]}>문제 설명</h2>
+            <div className={styles.desc}>{wargame.description}</div>
+
+            <div className={styles["submit-box"]}>
                 <input
                     type="text"
                     placeholder="플래그를 입력하세요"
                     value={flag}
                     onChange={(e) => setFlag(e.target.value)}
-                    style={{
-                        padding: "0.75rem",
-                        borderRadius: "0.5rem",
-                        border: "1px solid #ccc",
-                        marginRight: "1rem",
-                        width: "300px",
-                    }}
+                    className={styles.input}
                 />
-                <button
-                    onClick={submitFlag}
-                    style={{
-                        backgroundColor: "#FFA94D",
-                        border: "none",
-                        padding: "0.75rem 1.25rem",
-                        borderRadius: "0.5rem",
-                        color: "#fff",
-                        fontWeight: 600,
-                        cursor: "pointer",
-                    }}
-                >
+                <button onClick={submitFlag} className={styles["submit-btn"]}>
                     플래그 제출
                 </button>
+            </div>
+
+            {isModalOpen && modalResult && (
+                <div className={styles["modal-overlay"]} onClick={handleCloseModal}>
+                    <div
+                        className={`${styles["modal-box"]} ${modalResult.correct ? styles["correct"] : styles["wrong"]}`}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {modalResult.message !== "로그인이 되지 않았습니다. 로그인을 해주세요." && (
+                            <p style={{ fontSize: "1.1rem", fontWeight: 600 }}>
+                                {modalResult.correct ? "정답입니다!" : "틀렸습니다!"}
+                            </p>
+                        )}
+                        <p style={{ marginTop: "0.5rem", color: "#555" }}>{modalResult.message}</p>
+                        <button onClick={handleCloseModal} className={styles["submit-btn"]}>닫기</button>
+                    </div>
+                </div>
+            )}
+
+            <div className={styles["qa-section"]}>
+                <h2 className={styles["qa-title"]}>Q&A</h2>
+                {qaList.length === 0 ? (
+                    <p style={{ padding: "1rem", color: "#888" }}>아직 등록된 질문이 없습니다.</p>
+                ) : (
+                    qaList.map((q) => (
+                        <QACard
+                            key={q.id}
+                            question={{
+                                id: q.id,
+                                wargameTitle: String(wargame?.id || "알 수 없음"),
+                                title: q.title,
+                                content: q.content,
+                                username: q.username,
+                                createdAt: q.createdAt,
+                                answerCount: q.answers.length,
+                                likeCount: 0,
+                                viewCount: 0,
+                            }}
+                            isAnswered={q.answers.length > 0}
+                        />
+                    ))
+                )}
             </div>
         </div>
     );

--- a/guardians/src/pages/WargamePage/WargameTable.tsx
+++ b/guardians/src/pages/WargamePage/WargameTable.tsx
@@ -1,107 +1,146 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
+axios.defaults.withCredentials = true;
+
+type WargameRow = {
+    id: number;
+    title: string;
+    category: string;
+    level: string;
+    solved: boolean;
+};
 
 function WargameTable() {
-  const data = Array.from({ length: 54 }, (_, i) => ({
-    title: `문제 ${i + 1}`,
-    category: "웹",
-    level: i % 3 === 0 ? "쉬움" : i % 3 === 1 ? "보통" : "어려움",
-    solved: i % 2 === 0,
-  }));
+    const [data, setData] = useState<WargameRow[]>([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 20;
+    const API_BASE = import.meta.env.VITE_API_BASE_URL;
+    const navigate = useNavigate();
 
-  const itemsPerPage = 20;
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = Math.ceil(data.length / itemsPerPage);
-  const currentData = data.slice(
-      (currentPage - 1) * itemsPerPage,
-      currentPage * itemsPerPage
-  );
+    useEffect(() => {
+        axios.get(`${API_BASE}/api/wargames`)
+            .then((res) => {
+                const rawData = res.data.result.data;
 
-  return (
-      <div
-          style={{
-            backgroundColor: "white",
-            paddingBottom: "1rem",
-            paddingLeft: "1rem",
-            paddingRight: "1rem",
-            borderRadius: "8px",
-            border: "1px solid #ddd",
-          }}
-      >
-        <table
+                const categoryMap: Record<number, string> = {
+                    1: "웹",
+                    2: "리버싱",
+                    3: "포렌식",
+                    4: "암호",
+                    5: "시스템",
+                };
+
+                const transformed: WargameRow[] = rawData.map((item: any) => ({
+                    id: item.id,
+                    title: item.title,
+                    category: categoryMap[item.category] || "기타",
+                    level: item.difficulty || "알 수 없음",
+                    solved: item.solved,
+                }));
+
+                setData(transformed);
+            })
+            .catch((err) => {
+                console.error("데이터 불러오기 실패:", err);
+            });
+    }, []);
+
+    const totalPages = Math.ceil(data.length / itemsPerPage);
+    const currentData = data.slice(
+        (currentPage - 1) * itemsPerPage,
+        currentPage * itemsPerPage
+    );
+
+    return (
+        <div
             style={{
-              width: "100%",
-              borderCollapse: "separate",
-              borderSpacing: "0 8px",
+                backgroundColor: "white",
+                paddingBottom: "1rem",
+                paddingLeft: "1rem",
+                paddingRight: "1rem",
+                borderRadius: "8px",
+                border: "1px solid #ddd",
             }}
         >
-          <thead>
-          <tr style={{ textAlign: "left", fontSize: "0.9rem", color: "#555" }}>
-            <th style={{ ...thStyle, width: "10%" }}>상태</th>
-            <th style={{ ...thStyle, width: "55%" }}>문제</th> {/* ✅ 제일 길게 */}
-            <th style={{ ...thStyle, width: "15%" }}>분야</th>
-            <th style={{ ...thStyle, width: "20%" }}>난이도</th>
-          </tr>
-          </thead>
-          <tbody>
-          {currentData.map((row, idx) => (
-              <tr
-                  key={idx}
-                  style={{
-                    backgroundColor: "white",
-                    boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
-                    borderRadius: "6px",
-                    transition: "background 0.2s",
-                  }}
-                  onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
-                  onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
-              >
-                <td style={{ ...tdStyle, color: "#0c8", fontWeight: 600 }}>
-                  {row.solved ? "해결" : ""}
-                </td>
-                <td style={tdStyle}>{row.title}</td>
-                <td style={tdStyle}>{row.category}</td>
-                <td style={tdStyle}>{row.level}</td>
-              </tr>
-          ))}
-          </tbody>
-        </table>
+            <table
+                style={{
+                    width: "100%",
+                    borderCollapse: "separate",
+                    borderSpacing: "0 8px",
+                }}
+            >
+                <thead>
+                <tr style={{ textAlign: "left", fontSize: "0.9rem", color: "#555" }}>
+                    <th style={{ ...thStyle, width: "10%" }}>상태</th>
+                    <th style={{ ...thStyle, width: "55%" }}>문제</th>
+                    <th style={{ ...thStyle, width: "15%" }}>분야</th>
+                    <th style={{ ...thStyle, width: "20%" }}>난이도</th>
+                </tr>
+                </thead>
+                <tbody>
+                {currentData.map((row) => (
+                    <tr
+                        key={row.id}
+                        style={{
+                            backgroundColor: "white",
+                            boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+                            borderRadius: "6px",
+                            transition: "background 0.2s",
+                            cursor: "pointer",
+                        }}
+                        onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
+                        onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
+                        onClick={() => navigate(`/wargame/${row.id}`)}
+                    >
+                        <td style={{ ...tdStyle, color: "#0c8", fontWeight: 600 }}>
+                            {row.solved ? "해결" : ""}
+                        </td>
+                        <td style={tdStyle}>{row.title}</td>
+                        <td style={tdStyle}>{row.category}</td>
+                        <td style={tdStyle}>{row.level}</td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
 
-        {/* 페이징 */}
-        <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
-          {Array.from({ length: totalPages }, (_, i) => (
-              <button
-                  key={i}
-                  onClick={() => setCurrentPage(i + 1)}
-                  style={{
-                    margin: "0 0.25rem",
-                    padding: "0.4rem 0.75rem",
-                    backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
-                    color: currentPage === i + 1 ? "white" : "black",
-                    border: "none",
-                    borderRadius: "4px",
-                    cursor: "pointer",
-                  }}
-              >
-                {i + 1}
-              </button>
-          ))}
+            {/* 페이징 */}
+            <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                {Array.from({ length: totalPages }, (_, i) => (
+                    <button
+                        key={i}
+                        onClick={() => setCurrentPage(i + 1)}
+                        style={{
+                            margin: "0 0.25rem",
+                            padding: "0.4rem 0.75rem",
+                            backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
+                            color: currentPage === i + 1 ? "white" : "black",
+                            border: "none",
+                            borderRadius: "4px",
+                            cursor: "pointer",
+                        }}
+                    >
+                        {i + 1}
+                    </button>
+                ))}
+            </div>
         </div>
-      </div>
-  );
+    );
 }
 
 const thStyle = {
-  padding: "0.75rem 1rem",
-  fontWeight: 600,
-  borderBottom: "2px solid #ddd",
-  color: "#888",
-  fontSize: "0.9rem",
+    padding: "0.75rem 1rem",
+    fontWeight: 600,
+    borderBottom: "2px solid #ddd",
+    color: "#888",
+    fontSize: "0.9rem",
 };
 
 const tdStyle = {
-  padding: "0.75rem 1rem",
-  fontSize: "0.95rem",
-  textAlign: "left" as const,
+    padding: "0.75rem 1rem",
+    fontSize: "0.95rem",
+    textAlign: "left" as const,
 };
 
 export default WargameTable;


### PR DESCRIPTION
## 📌 PR 제목
- feat: 워게임 상세페이지에 Q&A 카드 리스트 표시 기능 추가

---

## ✨ 주요 변경사항
- 워게임 상세 페이지 하단에 Q&A 카드 리스트 섹션 추가
- 백엔드 API 호출하여 질문/답변 데이터 받아오기
- 기존 커뮤니티 Q&A 카드 디자인 재사용
- 질문 클릭 시 질문 상세 페이지로 이동 처리

---

## 🔍 상세 설명
- 워게임별로 등록된 질문을 사용자에게 보여주기 위한 기능입니다.
- `GET /api/qna/wargames/{wargameId}/questions`로 질문 목록을 받아오고, 각 질문별로 `GET /api/qna/answers/{questionId}`를 호출하여 답변 개수를 확인합니다.
- 카드 구성은 제목, 내용 요약, 작성자, 작성일, 답변수, 추천수, 조회수 및 답변 여부 뱃지 포함
- 카드 클릭 시 `navigate`를 통해 질문 상세 페이지로 이동

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 API 테스트
- [x] 프론트에서 연동 확인
- [ ] 유닛/통합 테스트 포함 (있다면)

---

## 📎 관련 이슈
Closes #123  <!-- 실제 이슈 번호 입력 -->

---

## 💬 기타 공유사항
- 답변 작성 기능은 추후 구현 예정
- 좋아요/조회수 API 연동 시 추가 필드 반영 필요
- 향후 질문 작성 버튼도 추가 예정
