### PR TITLE
feat: Add account deletion feature with confirmation modal on MyPage

### DIFF
--- a/guardians/src/components/Header.tsx
+++ b/guardians/src/components/Header.tsx
@@ -41,6 +41,9 @@ function Header() {
         }
     }, [isLoggedIn]);
 
+    useEffect(() => {
+        setDropdownOpen(false);
+    }, [location.pathname]);
 
     const toggleDropdown = () => {
         setDropdownOpen((prev) => !prev);

--- a/guardians/src/pages/MyPage/MypageInfoCard.tsx
+++ b/guardians/src/pages/MyPage/MypageInfoCard.tsx
@@ -4,6 +4,7 @@ import styles from "./MypagePage.module.css";
 import EditUsernameModal from "./components/EditUsernameModal";
 import EditPasswordModal from "./components/EditPasswordModal";
 import SuccessModal from "./components/SuccessModal";
+import DeleteUserModal from "./components/DeleteUserModal";
 import { useAuth } from "../../context/AuthContext";
 import editIcon from "../../assets/edit.png";
 
@@ -19,6 +20,7 @@ const MypageInfoCard = () => {
     const [showUsernameModal, setShowUsernameModal] = useState(false);
     const [showPasswordModal, setShowPasswordModal] = useState(false);
     const [showSuccessModal, setShowSuccessModal] = useState(false);
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [successMessage, setSuccessMessage] = useState("");
     const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
@@ -40,6 +42,21 @@ const MypageInfoCard = () => {
     useEffect(() => {
         fetchUserInfo();
     }, [fetchUserInfo]);
+
+    const handleDeleteUser = async () => {
+        if (!userId) return;
+        try {
+            await axios.delete(`${API_BASE}/api/users/${userId}`, {
+                withCredentials: true,
+            });
+            setSuccessMessage("회원 탈퇴가 완료되었습니다.");
+            setShowDeleteModal(false);
+            setShowSuccessModal(true);
+        } catch (err) {
+            console.error("탈퇴 실패:", err);
+            alert("탈퇴 중 오류 발생");
+        }
+    };
 
     const handleUsernameSuccess = () => {
         setSuccessMessage("닉네임이 성공적으로 변경되었습니다!");
@@ -68,14 +85,13 @@ const MypageInfoCard = () => {
             setSuccessMessage("프로필 이미지가 업로드되었습니다!");
             setShowSuccessModal(true);
         } catch (err) {
-            console.error("❌ 프로필 이미지 업로드 실패:", err);
+            console.error("프로필 이미지 업로드 실패:", err);
             alert("이미지 업로드 중 오류 발생");
         }
     };
 
     const handleImageDelete = async () => {
         if (!userId) return;
-
         try {
             await axios.delete(`${API_BASE}/api/users/${userId}/profile-image`, {
                 withCredentials: true,
@@ -83,7 +99,7 @@ const MypageInfoCard = () => {
             setSuccessMessage("프로필 이미지가 기본 이미지로 변경되었습니다!");
             setShowSuccessModal(true);
         } catch (err) {
-            console.error("❌ 프로필 이미지 삭제 실패:", err);
+            console.error("프로필 이미지 삭제 실패:", err);
             alert("이미지 삭제 중 오류 발생");
         }
     };
@@ -120,29 +136,38 @@ const MypageInfoCard = () => {
                 </button>
             )}
 
-            <div className={styles.infoItem}>
-                <label className={styles.infoLabel}>사용자 이름</label>
-                <div className={styles.inputRow}>
-                    <input type="text" className={styles.inputField} value={userInfo.username} readOnly />
-                    <button className={styles.editBtn} onClick={() => setShowUsernameModal(true)}>
-                        닉네임 수정
-                    </button>
+            {/* ✅ 전체 정보 영역 래퍼 */}
+            <div className={styles.infoWrapper}>
+                <div className={styles.infoItem}>
+                    <label className={styles.infoLabel}>사용자 이름</label>
+                    <div className={styles.inputRow}>
+                        <input type="text" className={styles.inputField} value={userInfo.username} readOnly />
+                        <button className={styles.editBtn} onClick={() => setShowUsernameModal(true)}>
+                            닉네임 수정
+                        </button>
+                    </div>
                 </div>
-            </div>
 
-            <div className={styles.infoItem}>
-                <label className={styles.infoLabel}>이메일</label>
-                <div className={styles.inputRow}>
-                    <input type="email" className={styles.inputField} value={userInfo.email} readOnly />
+                <div className={styles.infoItem}>
+                    <label className={styles.infoLabel}>이메일</label>
+                    <div className={styles.inputRow}>
+                        <input type="email" className={styles.inputField} value={userInfo.email} readOnly />
+                    </div>
                 </div>
-            </div>
 
-            <div className={styles.infoItem}>
-                <label className={styles.infoLabel}>비밀번호</label>
-                <div className={styles.inputRow}>
-                    <input type="password" className={styles.inputField} value="**********" readOnly />
-                    <button className={styles.editBtn} onClick={() => setShowPasswordModal(true)}>
-                        비밀번호 변경
+                <div className={styles.infoItem}>
+                    <label className={styles.infoLabel}>비밀번호</label>
+                    <div className={styles.inputRow}>
+                        <input type="password" className={styles.inputField} value="**********" readOnly />
+                        <button className={styles.editBtn} onClick={() => setShowPasswordModal(true)}>
+                            비밀번호 변경
+                        </button>
+                    </div>
+                </div>
+
+                <div style={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
+                    <button className={styles.deleteAccountBtn} onClick={() => setShowDeleteModal(true)}>
+                        회원 탈퇴
                     </button>
                 </div>
             </div>
@@ -166,8 +191,19 @@ const MypageInfoCard = () => {
                     message={successMessage}
                     onClose={() => {
                         setShowSuccessModal(false);
-                        window.location.reload();
+                        if (successMessage.includes("탈퇴")) {
+                            window.location.href = "/";
+                        } else {
+                            window.location.reload();
+                        }
                     }}
+                />
+            )}
+
+            {showDeleteModal && (
+                <DeleteUserModal
+                    onClose={() => setShowDeleteModal(false)}
+                    onConfirm={handleDeleteUser}
                 />
             )}
         </div>

--- a/guardians/src/pages/MyPage/MypagePage.module.css
+++ b/guardians/src/pages/MyPage/MypagePage.module.css
@@ -59,15 +59,16 @@
 /* ✅ 카드 (오른쪽 콘텐츠 영역) */
 .card {
     flex: 1 1 500px;
-    max-width: 70%;
+    max-width: 1200px;
     background-color: #fff;
     padding: 2rem;
     border-radius: 12px;
     box-shadow: 0 0 10px rgba(0,0,0,0.05);
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    margin-left: 0;
+    align-items: center;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .profileSection {
@@ -82,8 +83,8 @@
 /* ✅ 프로필 이미지 + 아이콘 */
 .avatarWrapper {
     position: relative;
-    width: 14rem;
-    height: 14rem;
+    width: 12rem;
+    height: 12rem;
     margin: 0 auto;
 }
 
@@ -118,7 +119,7 @@
 
 .resetBtn {
     display: block;
-    margin: 0.5rem auto 5rem auto; /* 위 여백 0.5rem, 좌우 가운데 정렬 */
+    margin: 0.5rem auto 5rem auto;
     background-color: white;
     color: #333;
     font-size: 0.9rem;
@@ -135,6 +136,16 @@
     background-color: #bbb;
 }
 
+.infoWrapper {
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2rem;
+}
+
 /* ✅ 정보 항목 (이름, 이메일, 비번) */
 .infoItem {
     display: flex;
@@ -147,7 +158,6 @@
 }
 
 .infoLabel {
-    margin-left: 5rem;
     font-size: 1rem;
     font-weight: 600;
     color: #1e1e1e;
@@ -156,38 +166,38 @@
 
 /* ✅ 인풋 + 버튼 한 줄 정렬 */
 .inputRow {
-    margin-left: 5rem;
     display: flex;
     align-items: center;
-    gap: 2rem;
+    gap: 1rem;
     width: 100%;
 }
 
-/* ✅ 인풋 필드 넓게 */
 .inputField {
     flex: 1;
-    max-width: 38rem;
     min-width: 0;
-    padding: 0.7rem;
+    max-width: 30rem;
+    padding: 0.65rem 0.75rem;   /* ✅ 높이 맞춤 */
     border: 1px solid #ccc;
     border-radius: 6px;
     font-size: 1rem;
     background-color: #f5f5f5;
+    box-sizing: border-box;     /* ✅ padding 포함해서 height 계산 */
+    line-height: 1.2;
 }
 
-/* ✅ 수정 버튼 */
 .editBtn {
-    padding: 0.7rem 1.2rem;
+    padding: 0.65rem 1.2rem;     /* ✅ 높이 인풋과 동일 */
     background-color: #FFA94D;
     color: white;
     border: none;
     border-radius: 6px;
     cursor: pointer;
-    font-size: 0.99rem;
+    font-size: 0.95rem;
     font-weight: 600;
-    height: 100%;
     white-space: nowrap;
     flex-shrink: 0;
+    box-sizing: border-box;
+    line-height: 1.2;
 }
 
 .editBtn:hover {
@@ -198,4 +208,22 @@
 .editBtn:focus {
     outline: none;
     border-color: #ccc;
+}
+
+/* ✅ 회원 탈퇴 버튼 (오른쪽 정렬) */
+.deleteAccountBtn {
+    background-color: #ffe3e3;
+    color: #d32f2f;
+    font-weight: 600;
+    border: 1px solid #f5c6cb;
+    padding: 0.65rem 1.2rem;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-top: 2rem;
+    align-self: flex-end;
+    transition: background-color 0.2s ease;
+}
+
+.deleteAccountBtn:hover {
+    background-color: #ffcccc;
 }

--- a/guardians/src/pages/MyPage/MypagePage.module.css
+++ b/guardians/src/pages/MyPage/MypagePage.module.css
@@ -147,7 +147,7 @@
 }
 
 .infoLabel {
-    margin-left: 15rem;
+    margin-left: 5rem;
     font-size: 1rem;
     font-weight: 600;
     color: #1e1e1e;
@@ -156,7 +156,7 @@
 
 /* ✅ 인풋 + 버튼 한 줄 정렬 */
 .inputRow {
-    margin-left: 15rem;
+    margin-left: 5rem;
     display: flex;
     align-items: center;
     gap: 2rem;

--- a/guardians/src/pages/MyPage/components/DeleteUserModal.tsx
+++ b/guardians/src/pages/MyPage/components/DeleteUserModal.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import styles from "./Modal.module.css";
+
+interface DeleteUserModalProps {
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+function DeleteUserModal({ onClose, onConfirm }: DeleteUserModalProps) {
+    const [inputValue, setInputValue] = useState("");
+
+    return (
+        <div className={styles.modalOverlay}>
+            <div className={styles.modalBox}>
+                {/* 모달 상단 */}
+                <div className={styles.modalHeader}>
+                    <h3 className={styles.modalTitle}>정말 탈퇴하시겠어요?</h3>
+                    <button className={styles.closeButton} onClick={onClose}>
+                        ✕
+                    </button>
+                </div>
+
+                <div className={styles.afterHeaderGap} />
+
+                {/* 경고 텍스트 */}
+                <p className={styles.warningText}>
+                    회원 탈퇴 시 모든 정보가 삭제되며 복구할 수 없습니다.<br />
+                    계속하려면 <strong>'삭제'</strong>라고 입력해주세요.
+                </p>
+
+                {/* 입력창 */}
+                <input
+                    className={styles.deleteConfirmInput}
+                    type="text"
+                    placeholder="삭제"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                />
+
+                {/* 버튼 영역 */}
+                <div className={styles.buttonRow}>
+                    <button className={styles.cancelBtn} onClick={onClose}>
+                        취소
+                    </button>
+                    <button
+                        className={styles.deleteButton}
+                        onClick={onConfirm}
+                        disabled={inputValue !== "삭제"}
+                    >
+                        탈퇴하기
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default DeleteUserModal;

--- a/guardians/src/pages/MyPage/components/Modal.module.css
+++ b/guardians/src/pages/MyPage/components/Modal.module.css
@@ -127,3 +127,37 @@
     outline: none;
 }
 
+.deleteConfirmInput {
+    padding: 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    width: 100%;
+    margin-top: 0.5rem;
+}
+
+.deleteButton {
+    padding: 0.6rem 1.2rem;
+    background-color: #ff6b6b;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.deleteButton:disabled {
+    background-color: #ffc9c9;
+    cursor: not-allowed;
+}
+
+.warningText {
+    font-size: 0.9rem;
+    color: #ff4d4f;
+    font-weight: 500;
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
+


### PR DESCRIPTION
## 📌 PR 제목
- feat: 마이페이지에 회원 탈퇴 기능 및 확인 모달 추가

---

## ✨ 주요 변경사항
- 마이페이지에 회원 탈퇴 버튼 추가  
- '삭제' 문구 입력 확인 모달(`DeleteUserModal`) 추가  
- 탈퇴 시 세션 만료 및 메인 페이지로 리디렉션  
- 마이페이지 인풋/버튼 레이아웃 반응형 개선

---

## 🔍 상세 설명
- 사용자가 계정을 스스로 삭제할 수 있도록 UI/기능 구현  
- 실수 방지를 위해 '삭제'라는 문구를 입력해야 탈퇴 가능  
- 백엔드에서 세션 무효화 처리 포함  
- 스타일 개선으로 모바일/데스크탑 모두 대응

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인  
- [x] 에러 핸들링 및 예외 처리 확인  
- [x] API 응답 형식 일관성 확인  
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman으로 API 삭제 테스트 완료  
- [x] 프론트에서 탈퇴 연동 확인  
- [ ] 유닛/통합 테스트 포함 (없음)

---

## 📎 관련 이슈
Closes #123

---

## 💬 기타 공유사항
- 기본 이미지 URL 롤백 처리도 함께 검증함  
- 추후 OAuth 사용자용 탈퇴 정책 도입 가능성 있음
