### PR TITLE
refact: unify layout max-width for CommunityPage with other pages

### DIFF
--- a/guardians/src/pages/HomePage/Home.tsx
+++ b/guardians/src/pages/HomePage/Home.tsx
@@ -1,6 +1,6 @@
 function Home() {
     return (
-        <div style={{ padding: "0", margin: "0", maxWidth: "100vw", marginLeft: "-5rem"}}>
+        <div style={{ padding: "0", margin: "0", maxWidth: "100vw"}}>
             {/* 배경색이 전체 너비로 적용되는 상단 Hero 영역 */}
             <div
                 style={{

--- a/guardians/src/pages/community/CommunityPage.tsx
+++ b/guardians/src/pages/community/CommunityPage.tsx
@@ -10,16 +10,16 @@ const CommunityPage = () => {
 
     return (
         <div style={{
-            marginTop: "1.5rem",
-            padding: "1rem",
             display: "flex",
-            justifyContent: "center"
+            justifyContent: "center",
+            padding: "2rem",
+            boxSizing: "border-box",
         }}>
             <div style={{
                 display: "flex",
-                gap: "1.5rem",
+                gap: "3.5rem",
                 maxWidth: "1200px",
-                width: "100%"
+                width: "100%",
             }}>
                 <Sidebar />
                 <div style={{ flex: 1 }}>

--- a/guardians/src/pages/community/FreeBoardDetailPage.tsx
+++ b/guardians/src/pages/community/FreeBoardDetailPage.tsx
@@ -36,34 +36,25 @@ const FreeBoardDetailPage = () => {
 
         axios.get(`/api/boards/${id}`, { withCredentials: true })
             .then(res => setBoard(res.data.result.data))
-            .catch((err) => {
-                console.error('게시글 로딩 오류:', err); // ← 사용하면 오류 안 남
-                alert('게시글을 불러오지 못했습니다.');
-            });
-
+            .catch(err => alert('게시글을 불러오지 못했습니다.'));
 
         axios.get(`/api/boards/${id}/comments`, { withCredentials: true })
-            .then(res => setComments(res.data.result.data))
+            .then(res => setComments(res.data.result.data));
 
         axios.get('/api/users/me', { withCredentials: true })
             .then(res => {
-                const id = res.data.result.data.id; //
-                console.log('✅ 로그인 유저 정보:', id);
+                const id = res.data.result.data.id;
                 setIsLoggedIn(true);
-                setSessionUserId(String(id)); //
+                setSessionUserId(String(id));
             })
-            .catch(err => {
-                console.error('❌ 로그인 확인 실패:', err);
+            .catch(() => {
                 setIsLoggedIn(false);
                 setSessionUserId(null);
             });
-
-
     }, [id]);
 
     const toggleLike = () => {
         if (!id) return;
-
         axios.post(`/api/boards/${id}/like`, { withCredentials: true })
             .then(res => {
                 const liked = res.data.result.data.liked;
@@ -72,8 +63,7 @@ const FreeBoardDetailPage = () => {
                     ...prev,
                     likeCount: prev.likeCount + (liked ? 1 : -1)
                 } : prev);
-            })
-            .catch(err => console.error("좋아요 토글 실패", err));
+            });
     };
 
     const handleDelete = () => {
@@ -83,10 +73,6 @@ const FreeBoardDetailPage = () => {
             .then(() => {
                 alert('게시글이 삭제되었습니다.');
                 navigate('/community/free');
-            })
-            .catch(err => {
-                console.error('삭제 실패', err);
-                alert('삭제에 실패했습니다.');
             });
     };
 
@@ -100,10 +86,6 @@ const FreeBoardDetailPage = () => {
             .then(res => {
                 setComments(prev => [...prev, res.data.result.data]);
                 setNewComment('');
-            })
-            .catch(err => {
-                console.error('댓글 작성 실패', err);
-                alert('댓글 작성에 실패했습니다.');
             });
     };
 
@@ -115,17 +97,20 @@ const FreeBoardDetailPage = () => {
         <div style={{
             display: 'flex',
             justifyContent: 'center',
-            alignItems: 'start',
-            minHeight: '10vh',
+            padding: '2rem',
+            boxSizing: 'border-box',
             backgroundColor: '#f5f5f5',
+            minHeight: '90vh',
         }}>
             <div style={{
-                width: '60%',
-                padding: '3.5rem',
+                width: '100%',
+                maxWidth: '800px',
                 background: '#fff',
                 border: '1px solid #ddd',
                 borderRadius: '8px',
                 boxShadow: '0 4px 10px rgba(0,0,0,0.05)',
+                padding: '3rem',
+                boxSizing: 'border-box',
             }}>
                 <button onClick={() => navigate(-1)}>←</button>
 
@@ -136,7 +121,6 @@ const FreeBoardDetailPage = () => {
                 <div style={{
                     display: 'flex',
                     justifyContent: 'space-between',
-                    alignItems: 'center',
                     fontSize: '0.95rem',
                     color: '#666',
                     marginBottom: '1rem'
@@ -145,7 +129,7 @@ const FreeBoardDetailPage = () => {
                     <div>추천 {board.likeCount} | 조회 {board.viewCount}</div>
                 </div>
 
-                <hr style={{ margin: '1rem 0', border: '1px solid #ccc' }} />
+                <hr />
 
                 <div style={{
                     whiteSpace: 'pre-wrap',
@@ -157,17 +141,14 @@ const FreeBoardDetailPage = () => {
                     {board.content}
                 </div>
 
-                <hr style={{ margin: '1rem 0', border: '1px solid #ccc' }} />
+                <hr style={{ margin: '1.5rem 0' }} />
 
                 <div style={{
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
-                    marginBottom: '0.5rem'
                 }}>
-                    <h2 style={{ fontSize: '1.2rem', fontWeight: 600, margin: 0 }}>
-                        댓글 {comments.length}
-                    </h2>
+                    <h2 style={{ fontSize: '1.2rem' }}>댓글 {comments.length}</h2>
                     <button
                         onClick={toggleLike}
                         disabled={!isLoggedIn}
@@ -179,78 +160,78 @@ const FreeBoardDetailPage = () => {
                             cursor: isLoggedIn ? 'pointer' : 'not-allowed',
                             fontWeight: '500',
                             color: isLiked ? '#6b4bb8' : '#555',
-                            opacity: isLoggedIn ? 1 : 0.5,
                         }}
                     >
                         {isLiked ? '❤️ 좋아요 취소' : '🤍 좋아요'}
                     </button>
                 </div>
 
-
-                {isLoggedIn && board && String(sessionUserId) === String(board.userId) && (
+                {isLoggedIn && String(sessionUserId) === String(board.userId) && (
                     <div style={{ textAlign: 'right', marginTop: '1.5rem' }}>
                         <button onClick={handleDelete}>삭제하기</button>
                     </div>
                 )}
 
-
-                {comments.length === 0 ? (
-                    <div className="p-4 border border-gray-200 rounded-md text-gray-500 text-sm">
-                        아직 댓글이 없습니다.
-                    </div>
-                ) : (
-                    <ul style={{ marginTop: '1rem' }}>
-                        {comments.map(comment => (
-                            <li key={comment.commentId} style={{
-                                marginBottom: '1rem',
-                                padding: '1rem',
-                                border: '1px solid #e0e0e0',
-                                borderRadius: '6px',
-                                backgroundColor: '#f9f9f9'
-                            }}>
-                                <div style={{ fontSize: '0.9rem', color: '#555', marginBottom: '0.3rem' }}>
-                                    {comment.username} · {new Date(comment.createdAt).toLocaleDateString()}
-                                </div>
-                                <div style={{ whiteSpace: 'pre-wrap' }}>{comment.content}</div>
-                            </li>
-                        ))}
-                    </ul>
-                )}
-
-                {(
-                    <div style={{ marginTop: '1.5rem' }}>
-                        <textarea
-                            placeholder="댓글을 입력하세요"
-                            value={newComment}
-                            onChange={(e) => setNewComment(e.target.value)}
-                            style={{
-                                width: '100%',
-                                height: '80px',
-                                padding: '0.8rem',
-                                fontSize: '1rem',
-                                borderRadius: '6px',
-                                border: '1px solid #ccc',
-                                resize: 'none',
-                            }}
-                        />
-                        <div style={{ textAlign: 'right', marginTop: '0.5rem' }}>
-                            <button
-                                onClick={handleCommentSubmit}
-                                style={{
-                                    backgroundColor: '#6b4bb8',
-                                    color: '#fff',
-                                    padding: '0.5rem 1.2rem',
-                                    border: 'none',
-                                    borderRadius: '6px',
-                                    cursor: 'pointer',
-                                    fontWeight: 'bold'
-                                }}
-                            >
-                                등록
-                            </button>
+                <div style={{ marginTop: '2rem' }}>
+                    {comments.length === 0 ? (
+                        <div style={{
+                            padding: '1rem',
+                            border: '1px solid #eee',
+                            borderRadius: '8px',
+                            color: '#777',
+                            textAlign: 'center'
+                        }}>
+                            아직 댓글이 없습니다.
                         </div>
+                    ) : (
+                        <ul>
+                            {comments.map(comment => (
+                                <li key={comment.commentId} style={{
+                                    padding: '1rem',
+                                    borderBottom: '1px solid #eee'
+                                }}>
+                                    <div style={{ fontSize: '0.9rem', color: '#555' }}>
+                                        {comment.username} · {new Date(comment.createdAt).toLocaleDateString()}
+                                    </div>
+                                    <div style={{ whiteSpace: 'pre-wrap', marginTop: '0.5rem' }}>{comment.content}</div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                <div style={{ marginTop: '2rem' }}>
+                    <textarea
+                        placeholder="댓글을 입력하세요"
+                        value={newComment}
+                        onChange={(e) => setNewComment(e.target.value)}
+                        style={{
+                            width: '100%',
+                            height: '80px',
+                            padding: '0.8rem',
+                            fontSize: '1rem',
+                            borderRadius: '6px',
+                            border: '1px solid #ccc',
+                            resize: 'none',
+                        }}
+                    />
+                    <div style={{ textAlign: 'right', marginTop: '0.5rem' }}>
+                        <button
+                            onClick={handleCommentSubmit}
+                            style={{
+                                backgroundColor: '#6b4bb8',
+                                color: '#fff',
+                                padding: '0.5rem 1.2rem',
+                                border: 'none',
+                                borderRadius: '6px',
+                                cursor: 'pointer',
+                                fontWeight: 'bold'
+                            }}
+                        >
+                            등록
+                        </button>
                     </div>
-                )}
+                </div>
             </div>
         </div>
     );

--- a/guardians/src/pages/community/FreeBoardPage.tsx
+++ b/guardians/src/pages/community/FreeBoardPage.tsx
@@ -52,102 +52,122 @@ const FreeBoardPage = () => {
     };
 
     return (
-        <div style={{ width: "90%", marginTop: "1.5rem", display: "flex", gap: "3.5rem", padding: "1rem" }}>
-            <Sidebar />
-            <div style={{ flex: 1 }}>
-                {/* 🔥 상단 색 섹션 */}
-                <div
-                    style={{
-                        backgroundColor: "#fdf3e7",
-                        padding: "1rem",
-                        borderRadius: "8px",
-                        marginBottom: "1.5rem",
-                        border: "1px solid #ddd",
-                    }}
-                >
-                    <h2 style={{ margin: 0, fontWeight: 600 }}>자유 게시판</h2>
-                    <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
-                        ✍️ 하고싶은 이야기를 자유롭게 나눠보세요!
-                    </p>
-                </div>
-                {/* 🔍 검색창 + 글쓰기 버튼 한 줄에 정렬 */}
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
-                    <SearchBar />
-                    <button
+        <div style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "2rem",
+            boxSizing: "border-box",
+        }}>
+            <div style={{
+                display: "flex",
+                gap: "3.5rem",
+                maxWidth: "1200px",
+                width: "100%",
+            }}>
+                <Sidebar />
+                <div style={{ flex: 1 }}>
+                    {/* 🔥 상단 색 섹션 */}
+                    <div
                         style={{
-                            backgroundColor: "#FFA94D",
-                            color: "#fff",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "0.5rem 1rem",
-                            fontSize: "0.9rem",
-                            fontWeight: 550,
-                            cursor: "pointer",
-                            marginRight: "0.5rem",
-                            width: "10%"
+                            backgroundColor: "#fdf3e7",
+                            padding: "1rem",
+                            borderRadius: "8px",
+                            marginBottom: "1.5rem",
+                            border: "1px solid #ddd",
                         }}
-                        onClick={handleWriteClick}
                     >
-                        글쓰기
-                    </button>
-                </div>
+                        <h2 style={{ margin: 0, fontWeight: 600 }}>자유 게시판</h2>
+                        <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
+                            ✍️ 하고싶은 이야기를 자유롭게 나눠보세요!
+                        </p>
+                    </div>
 
-                <table style={{ width: "100%", borderCollapse: "collapse", backgroundColor: "#fff", border: "1px solid #ddd", borderRadius: "5px", overflow: "hidden" }}>
-                    <thead>
-                    <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
-                        <th style={{ ...th, width: "40%" }}>제목</th>
-                        <th style={{ ...th, width: "15%" }}>작성자</th>
-                        <th style={{ ...th, width: "15%" }}>작성일</th>
-                        <th style={{ ...th, width: "15%" }}>추천수</th>
-                        <th style={{ ...th, width: "15%" }}>조회수</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {currentBoards.map((board) => (
-                        <tr
-                            key={board.boardId}
-                            onClick={() => handleRowClick(board.boardId)}
-                            style={{
-                                borderTop: "1px solid #eee",
-                                cursor: "pointer",
-                                transition: "background 0.2s",
-                            }}
-                            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
-                            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
-                        >
-                            <td style={td}>{board.title}</td>
-                            <td style={td}>{board.username}</td>
-                            <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
-                            <td style={td}>{board.likeCount}</td>
-                            <td style={td}>{board.viewCount}</td>
-                        </tr>
-                    ))}
-                    </tbody>
-                </table>
-
-                {/* ⏩ 페이징 */}
-                <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
-                    {Array.from({ length: totalPages }, (_, i) => (
+                    {/* 🔍 검색창 + 글쓰기 버튼 한 줄에 정렬 */}
+                    <div style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "1.5rem"
+                    }}>
+                        <SearchBar />
                         <button
-                            key={i}
-                            onClick={() => setCurrentPage(i + 1)}
                             style={{
-                                margin: "0 0.25rem",
-                                padding: "0.4rem 0.75rem",
-                                backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
-                                color: currentPage === i + 1 ? "white" : "black",
+                                backgroundColor: "#FFA94D",
+                                color: "#fff",
                                 border: "none",
-                                borderRadius: "4px",
+                                borderRadius: "6px",
+                                padding: "0.5rem 1rem",
+                                fontSize: "0.9rem",
+                                fontWeight: 550,
                                 cursor: "pointer",
+                                marginRight: "0.5rem",
+                                width: "10%"
                             }}
+                            onClick={handleWriteClick}
                         >
-                            {i + 1}
+                            글쓰기
                         </button>
-                    ))}
+                    </div>
+
+                    {/* 테이블 */}
+                    <table style={{ width: "100%", borderCollapse: "collapse", backgroundColor: "#fff", border: "1px solid #ddd", borderRadius: "5px", overflow: "hidden" }}>
+                        <thead>
+                        <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
+                            <th style={{ ...th, width: "40%" }}>제목</th>
+                            <th style={{ ...th, width: "15%" }}>작성자</th>
+                            <th style={{ ...th, width: "15%" }}>작성일</th>
+                            <th style={{ ...th, width: "15%" }}>추천수</th>
+                            <th style={{ ...th, width: "15%" }}>조회수</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currentBoards.map((board) => (
+                            <tr
+                                key={board.boardId}
+                                onClick={() => handleRowClick(board.boardId)}
+                                style={{
+                                    borderTop: "1px solid #eee",
+                                    cursor: "pointer",
+                                    transition: "background 0.2s",
+                                }}
+                                onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
+                                onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
+                            >
+                                <td style={td}>{board.title}</td>
+                                <td style={td}>{board.username}</td>
+                                <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
+                                <td style={td}>{board.likeCount}</td>
+                                <td style={td}>{board.viewCount}</td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+
+                    {/* ⏩ 페이징 */}
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
+                                    color: currentPage === i + 1 ? "white" : "black",
+                                    border: "none",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>
     );
+
 };
 
 const th = {

--- a/guardians/src/pages/community/InquiryBoardPage.tsx
+++ b/guardians/src/pages/community/InquiryBoardPage.tsx
@@ -4,7 +4,6 @@ import {useNavigate} from "react-router-dom";
 import {useEffect, useState} from "react";
 import axios from "axios";
 
-
 const InquiryBoardPage = () => {
     const navigate = useNavigate();
 
@@ -17,6 +16,7 @@ const InquiryBoardPage = () => {
         viewCount: number;
         boardType: string;
     }
+
     const [boards, setBoards] = useState<Board[]>([]);
     const boardsPerPage = 10;
     const [currentPage, setCurrentPage] = useState(1);
@@ -26,7 +26,9 @@ const InquiryBoardPage = () => {
             .then(res => {
                 const result = res.data.result.data;
                 if (Array.isArray(result)) {
-                    const sortedBoards = result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+                    const sortedBoards = result.sort((a, b) =>
+                        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+                    );
                     setBoards(sortedBoards);
                 } else {
                     setBoards([]);
@@ -52,101 +54,124 @@ const InquiryBoardPage = () => {
     };
 
     return (
-        <div style={{ width: "90%", marginTop: "1.5rem", display: "flex", gap: "3.5rem", padding: "1rem" }}>
-            <Sidebar />
-            <div style={{ flex: 1}}>
-                {/* 🔥 상단 색 섹션 */}
-                <div
-                    style={{
-                        backgroundColor: "#e0f6f3",
-                        padding: "1rem",
-                        borderRadius: "8px",
-                        marginBottom: "1.5rem",
-                        border: "1px solid #ddd",
-                    }}
-                >
-                    <h2 style={{ margin: 0, fontWeight: 600 }}>문의 게시판</h2>
-                    <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
-                        📩   관리자에게 문의사항이 있다면 올려주세요️!
-                    </p>
-                </div>
-                {/* 🔍 검색창 + 글쓰기 버튼 한 줄에 정렬 */}
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
-                    <SearchBar />
-                    <button
+        <div style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "2rem",
+            boxSizing: "border-box",
+        }}>
+            <div style={{
+                display: "flex",
+                gap: "3.5rem",
+                maxWidth: "1200px",
+                width: "100%",
+            }}>
+                <Sidebar />
+                <div style={{ flex: 1 }}>
+                    {/* 🔥 상단 색 섹션 */}
+                    <div
                         style={{
-                            backgroundColor: "#FFA94D",
-                            color: "#fff",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "0.5rem 1rem",
-                            fontSize: "0.9rem",
-                            fontWeight: 550,
-                            cursor: "pointer",
-                            marginRight: "0.5rem",
-                            width: "10%"
+                            backgroundColor: "#e0f6f3",
+                            padding: "1rem",
+                            borderRadius: "8px",
+                            marginBottom: "1.5rem",
+                            border: "1px solid #ddd",
                         }}
-                        onClick={handleWriteClick}
                     >
-                        글쓰기
-                    </button>
-                </div>
+                        <h2 style={{ margin: 0, fontWeight: 600 }}>문의 게시판</h2>
+                        <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
+                            📩 관리자에게 문의사항이 있다면 올려주세요️!
+                        </p>
+                    </div>
 
-
-                {/* 📋 게시글 테이블 */}
-                <table style={{ width: "100%", borderCollapse: "collapse", backgroundColor: "#fff", border: "1px solid #ddd",  borderRadius: "5px", overflow: "hidden"}}>
-                    <thead>
-                    <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
-                        <th style={{ ...th, width: "40%" }}>제목</th>
-                        <th style={{ ...th, width: "15%" }}>작성자</th>
-                        <th style={{ ...th, width: "15%" }}>작성일</th>
-                        <th style={{ ...th, width: "15%" }}>추천수</th>
-                        <th style={{ ...th, width: "15%" }}>조회수</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {currentBoards.map((board) => (
-                        <tr
-                            key={board.boardId}
-                            onClick={() => handleRowClick(board.boardId)}
-                            style={{
-                                borderTop: "1px solid #eee",
-                                cursor: "pointer",
-                                transition: "background 0.2s",
-                            }}
-                            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
-                            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
-                        >
-                            <td style={td}>{board.title}</td>
-                            <td style={td}>{board.username}</td>
-                            <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
-                            <td style={td}>{board.likeCount}</td>
-                            <td style={td}>{board.viewCount}</td>
-                        </tr>
-                    ))}
-                    </tbody>
-
-                </table>
-
-                {/* ⏩ 페이징 */}
-                <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
-                    {Array.from({ length: totalPages }, (_, i) => (
+                    {/* 🔍 검색창 + 글쓰기 버튼 */}
+                    <div style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "1.5rem"
+                    }}>
+                        <SearchBar />
                         <button
-                            key={i}
-                            onClick={() => setCurrentPage(i + 1)}
                             style={{
-                                margin: "0 0.25rem",
-                                padding: "0.4rem 0.75rem",
-                                backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
-                                color: currentPage === i + 1 ? "white" : "black",
+                                backgroundColor: "#FFA94D",
+                                color: "#fff",
                                 border: "none",
-                                borderRadius: "4px",
+                                borderRadius: "6px",
+                                padding: "0.5rem 1rem",
+                                fontSize: "0.9rem",
+                                fontWeight: 550,
                                 cursor: "pointer",
+                                marginRight: "0.5rem",
+                                width: "10%"
                             }}
+                            onClick={handleWriteClick}
                         >
-                            {i + 1}
+                            글쓰기
                         </button>
-                    ))}
+                    </div>
+
+                    {/* 📋 게시글 테이블 */}
+                    <table style={{
+                        width: "100%",
+                        borderCollapse: "collapse",
+                        backgroundColor: "#fff",
+                        border: "1px solid #ddd",
+                        borderRadius: "5px",
+                        overflow: "hidden"
+                    }}>
+                        <thead>
+                        <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
+                            <th style={{ ...th, width: "40%" }}>제목</th>
+                            <th style={{ ...th, width: "15%" }}>작성자</th>
+                            <th style={{ ...th, width: "15%" }}>작성일</th>
+                            <th style={{ ...th, width: "15%" }}>추천수</th>
+                            <th style={{ ...th, width: "15%" }}>조회수</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currentBoards.map((board) => (
+                            <tr
+                                key={board.boardId}
+                                onClick={() => handleRowClick(board.boardId)}
+                                style={{
+                                    borderTop: "1px solid #eee",
+                                    cursor: "pointer",
+                                    transition: "background 0.2s",
+                                }}
+                                onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
+                                onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
+                            >
+                                <td style={td}>{board.title}</td>
+                                <td style={td}>{board.username}</td>
+                                <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
+                                <td style={td}>{board.likeCount}</td>
+                                <td style={td}>{board.viewCount}</td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+
+                    {/* ⏩ 페이징 */}
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
+                                    color: currentPage === i + 1 ? "white" : "black",
+                                    border: "none",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>

--- a/guardians/src/pages/community/QnaBoardPage.tsx
+++ b/guardians/src/pages/community/QnaBoardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import Sidebar from "./components/Sidebar";
 import SearchBar from "./components/SearchBar";
 import viewIcon from "../../assets/view.png";
@@ -15,7 +15,6 @@ type QnaPost = {
     answerCount?: number;
 };
 
-
 const QnaBoardPage = () => {
     const [posts, setPosts] = useState<QnaPost[]>([]);
     const [currentPage, setCurrentPage] = useState(1);
@@ -27,7 +26,6 @@ const QnaBoardPage = () => {
                 const res = await axios.get("/api/qna/questions");
                 const questions: QnaPost[] = res.data.result.data;
 
-                // 각 질문에 대한 답변 count 불러오기
                 const questionsWithCount = await Promise.all(
                     questions.map(async (q) => {
                         try {
@@ -54,130 +52,142 @@ const QnaBoardPage = () => {
     const currentPosts = posts.slice((currentPage - 1) * postsPerPage, currentPage * postsPerPage);
 
     return (
-        <div style={{ width: "90%", marginTop: "1.5rem", display: "flex", gap: "3.5rem", padding: "1rem" }}>
-            <Sidebar />
-            <div style={{ flex: 1 }}>
-                <div
-                    style={{
-                        backgroundColor: "#eae7f8",
-                        padding: "1rem",
-                        borderRadius: "8px",
-                        marginBottom: "1.5rem",
-                        border: "1px solid #ddd",
-                    }}
-                >
-                    <h2 style={{ margin: 0, fontWeight: 600 }}>워게임 Q&A</h2>
-                    <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
-                        올라온 질문을 확인하고 자유롭게 답변해보세요!
-                    </p>
-                </div>
-
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
-                    <SearchBar />
-                    <button
+        <div style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "2rem",
+            boxSizing: "border-box",
+        }}>
+            <div style={{
+                display: "flex",
+                gap: "3.5rem",
+                maxWidth: "1200px",
+                width: "100%"
+            }}>
+                <Sidebar />
+                <div style={{ flex: 1 }}>
+                    <div
                         style={{
-                            backgroundColor: "#FFA94D",
-                            color: "#fff",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "0.5rem 1rem",
-                            fontSize: "0.9rem",
-                            fontWeight: 550,
-                            cursor: "pointer",
-                            marginRight: "0.5rem",
-                            width: "10%",
+                            backgroundColor: "#eae7f8",
+                            padding: "1rem",
+                            borderRadius: "8px",
+                            marginBottom: "1.5rem",
+                            border: "1px solid #ddd",
                         }}
-                        onClick={() => alert("글쓰기 클릭!")}
                     >
-                        질문하기
-                    </button>
-                </div>
+                        <h2 style={{ margin: 0, fontWeight: 600 }}>워게임 Q&A</h2>
+                        <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
+                            올라온 질문을 확인하고 자유롭게 답변해보세요!
+                        </p>
+                    </div>
 
-                <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
-                    {currentPosts.map((post) => (
-                        <div
-                            key={post.id}
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
+                        <SearchBar />
+                        <button
                             style={{
-                                backgroundColor: "#fff",
-                                padding: "1.5rem",
-                                borderRadius: "12px",
-                                border: "1px solid #eee",
-                                boxShadow: "0 4px 10px rgba(0, 0, 0, 0.04)",
+                                backgroundColor: "#FFA94D",
+                                color: "#fff",
+                                border: "none",
+                                borderRadius: "6px",
+                                padding: "0.5rem 1rem",
+                                fontSize: "0.9rem",
+                                fontWeight: 550,
                                 cursor: "pointer",
-                                transition: "box-shadow 0.2s",
+                                marginRight: "0.5rem",
+                                width: "10%",
                             }}
-                            onClick={() => alert(`Q&A 상세로 이동 ID: ${post.id}`)}
-                            onMouseOver={(e) => (e.currentTarget.style.boxShadow = "0 6px 16px rgba(0,0,0,0.1)")}
-                            onMouseOut={(e) => (e.currentTarget.style.boxShadow = "0 4px 10px rgba(0, 0, 0, 0.04)")}
+                            onClick={() => alert("글쓰기 클릭!")}
                         >
-                            <div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem", marginBottom: "0.4rem" }}>
-                                <span style={{ fontWeight: 500, color: "#888" }}>{post.wargameTitle || "워게임 미지정"}</span>
-                                <span style={{ color: "#666" }}>{post.username} · {post.createdAt.slice(0, 10)}</span>
-                            </div>
+                            질문하기
+                        </button>
+                    </div>
 
-                            <div style={{ fontSize: "1.15rem", fontWeight: 700, margin: "0.4rem 0 1rem", lineHeight: "1.4" }}>
-                                {post.title}
-                            </div>
-
-                            <div style={{ fontSize: "0.9rem", color: "#444", marginBottom: "0.8rem", lineHeight: "1.5" }}>
-                                {post.content.length > 150 ? post.content.slice(0, 150) + "..." : post.content}
-                            </div>
-
-                            <hr style={{ border: "none", borderTop: "1px solid #eee", margin: "0.5rem 0 1rem" }} />
-
+                    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+                        {currentPosts.map((post) => (
                             <div
+                                key={post.id}
                                 style={{
-                                    display: "flex",
-                                    justifyContent: "space-between",
-                                    alignItems: "center",
-                                    flexWrap: "wrap",
+                                    backgroundColor: "#fff",
+                                    padding: "1.5rem",
+                                    borderRadius: "12px",
+                                    border: "1px solid #eee",
+                                    boxShadow: "0 4px 10px rgba(0, 0, 0, 0.04)",
+                                    cursor: "pointer",
+                                    transition: "box-shadow 0.2s",
                                 }}
+                                onClick={() => alert(`Q&A 상세로 이동 ID: ${post.id}`)}
+                                onMouseOver={(e) => (e.currentTarget.style.boxShadow = "0 6px 16px rgba(0,0,0,0.1)")}
+                                onMouseOut={(e) => (e.currentTarget.style.boxShadow = "0 4px 10px rgba(0, 0, 0, 0.04)")}
                             >
-                                <div style={{ display: "flex", gap: "1.25rem", fontSize: "0.85rem", color: "#555" }}>
-                                    <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-                                        <img src={commentIcon} alt="comment" style={{ width: "16px", height: "16px" }} />
-                                        <span>{post.answerCount ?? 0} 답변</span>
-                                    </div>
-                                    <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-                                        <img src={viewIcon} alt="view" style={{ width: "18px", height: "18px" }} />
-                                        <span>- 조회</span>
-                                    </div>
+                                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem", marginBottom: "0.4rem" }}>
+                                    <span style={{ fontWeight: 500, color: "#888" }}>{post.wargameTitle || "워게임 미지정"}</span>
+                                    <span style={{ color: "#666" }}>{post.username} · {post.createdAt.slice(0, 10)}</span>
                                 </div>
-                                <span
+
+                                <div style={{ fontSize: "1.15rem", fontWeight: 700, margin: "0.4rem 0 1rem", lineHeight: "1.4" }}>
+                                    {post.title}
+                                </div>
+
+                                <div style={{ fontSize: "0.9rem", color: "#444", marginBottom: "0.8rem", lineHeight: "1.5" }}>
+                                    {post.content.length > 150 ? post.content.slice(0, 150) + "..." : post.content}
+                                </div>
+
+                                <hr style={{ border: "none", borderTop: "1px solid #eee", margin: "0.5rem 0 1rem" }} />
+
+                                <div
                                     style={{
-                                        backgroundColor: post.answerCount && post.answerCount > 0 ? "#D3F9D8" : "#FFF3BF",
-                                        color: post.answerCount && post.answerCount > 0 ? "#2B8A3E" : "#C77D00",
-                                        fontSize: "0.75rem",
-                                        fontWeight: 600,
-                                        padding: "0.35rem 0.8rem",
-                                        borderRadius: "999px",
+                                        display: "flex",
+                                        justifyContent: "space-between",
+                                        alignItems: "center",
+                                        flexWrap: "wrap",
                                     }}
                                 >
-                                {post.answerCount && post.answerCount > 0 ? "답변완료" : "미답변"}
-                            </span>
+                                    <div style={{ display: "flex", gap: "1.25rem", fontSize: "0.85rem", color: "#555" }}>
+                                        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                            <img src={commentIcon} alt="comment" style={{ width: "16px", height: "16px" }} />
+                                            <span>{post.answerCount ?? 0} 답변</span>
+                                        </div>
+                                        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                            <img src={viewIcon} alt="view" style={{ width: "18px", height: "18px" }} />
+                                            <span>- 조회</span>
+                                        </div>
+                                    </div>
+                                    <span
+                                        style={{
+                                            backgroundColor: post.answerCount && post.answerCount > 0 ? "#D3F9D8" : "#FFF3BF",
+                                            color: post.answerCount && post.answerCount > 0 ? "#2B8A3E" : "#C77D00",
+                                            fontSize: "0.75rem",
+                                            fontWeight: 600,
+                                            padding: "0.35rem 0.8rem",
+                                            borderRadius: "999px",
+                                        }}
+                                    >
+                                    {post.answerCount && post.answerCount > 0 ? "답변완료" : "미답변"}
+                                </span>
+                                </div>
                             </div>
-                        </div>
-                    ))}
-                </div>
+                        ))}
+                    </div>
 
-                <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
-                    {Array.from({ length: totalPages }, (_, i) => (
-                        <button
-                            key={i}
-                            onClick={() => setCurrentPage(i + 1)}
-                            style={{
-                                margin: "0 0.25rem",
-                                padding: "0.4rem 0.75rem",
-                                backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
-                                color: currentPage === i + 1 ? "white" : "black",
-                                border: "none",
-                                borderRadius: "4px",
-                                cursor: "pointer",
-                            }}
-                        >
-                            {i + 1}
-                        </button>
-                    ))}
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
+                                    color: currentPage === i + 1 ? "white" : "black",
+                                    border: "none",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>

--- a/guardians/src/pages/community/StudyBoardPage.tsx
+++ b/guardians/src/pages/community/StudyBoardPage.tsx
@@ -1,9 +1,8 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import Sidebar from "./components/Sidebar";
 import SearchBar from "./components/SearchBar";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
-
 
 const StudyBoardPage = () => {
     const navigate = useNavigate();
@@ -27,7 +26,9 @@ const StudyBoardPage = () => {
             .then(res => {
                 const result = res.data.result.data;
                 if (Array.isArray(result)) {
-                    const sortedBoards = result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+                    const sortedBoards = result.sort(
+                        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+                    );
                     setBoards(sortedBoards);
                 } else {
                     setBoards([]);
@@ -43,6 +44,7 @@ const StudyBoardPage = () => {
         (currentPage - 1) * boardsPerPage,
         currentPage * boardsPerPage
     );
+
     const handleRowClick = (id: number) => {
         navigate(`/community/study/${id}`);
     };
@@ -50,102 +52,126 @@ const StudyBoardPage = () => {
     const handleWriteClick = () => {
         navigate("/community/study/write");
     };
+
     return (
-        <div style={{ width: "90%", marginTop: "1.5rem", display: "flex", gap: "3.5rem", padding: "1rem" }}>
-            <Sidebar />
-            <div style={{ flex: 1}}>
-                {/* 🔥 상단 색 섹션 */}
-                <div
-                    style={{
-                        backgroundColor: "#fdeaf4",
-                        padding: "1rem",
-                        borderRadius: "8px",
-                        marginBottom: "1.5rem",
-                        border: "1px solid #ddd",
-                    }}
-                >
-                    <h2 style={{ margin: 0, fontWeight: 600 }}>스터디 모집</h2>
-                    <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
-                        📚 함께 스터디를 할 팀원들을 구해보세요!
-                    </p>
-                </div>
-                {/* 🔍 검색창 + 글쓰기 버튼 한 줄에 정렬 */}
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
-                    <SearchBar />
-                    <button
+        <div style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "2rem",
+            boxSizing: "border-box",
+        }}>
+            <div style={{
+                display: "flex",
+                gap: "3.5rem",
+                maxWidth: "1200px",
+                width: "100%",
+            }}>
+                <Sidebar />
+                <div style={{ flex: 1 }}>
+                    {/* 🔥 상단 색 섹션 */}
+                    <div
                         style={{
-                            backgroundColor: "#FFA94D",
-                            color: "#fff",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "0.5rem 1rem",
-                            fontSize: "0.9rem",
-                            fontWeight: 550,
-                            cursor: "pointer",
-                            marginRight: "0.5rem",
-                            width: "10%"
+                            backgroundColor: "#fdeaf4",
+                            padding: "1rem",
+                            borderRadius: "8px",
+                            marginBottom: "1.5rem",
+                            border: "1px solid #ddd",
                         }}
-                        onClick={handleWriteClick}
                     >
-                        글쓰기
-                    </button>
-                </div>
+                        <h2 style={{ margin: 0, fontWeight: 600 }}>스터디 모집</h2>
+                        <p style={{ fontSize: "0.9rem", color: "#555", marginTop: "0.5rem" }}>
+                            📚 함께 스터디를 할 팀원들을 구해보세요!
+                        </p>
+                    </div>
 
-
-                {/* 📋 게시글 테이블 */}
-                <table style={{ width: "100%", borderCollapse: "collapse", backgroundColor: "#fff", border: "1px solid #ddd",  borderRadius: "5px", overflow: "hidden"}}>
-                    <thead>
-                    <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
-                        <th style={{ ...th, width: "40%" }}>제목</th>
-                        <th style={{ ...th, width: "15%" }}>작성자</th>
-                        <th style={{ ...th, width: "15%" }}>작성일</th>
-                        <th style={{ ...th, width: "15%" }}>추천수</th>
-                        <th style={{ ...th, width: "15%" }}>조회수</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {currentBoards.map((board) => (
-                        <tr
-                            key={board.boardId}
-                            onClick={() => handleRowClick(board.boardId)}
-                            style={{
-                                borderTop: "1px solid #eee",
-                                cursor: "pointer",
-                                transition: "background 0.2s",
-                            }}
-                            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
-                            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
-                        >
-                            <td style={td}>{board.title}</td>
-                            <td style={td}>{board.username}</td>
-                            <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
-                            <td style={td}>{board.likeCount}</td>
-                            <td style={td}>{board.viewCount}</td>
-                        </tr>
-                    ))}
-                    </tbody>
-
-                </table>
-
-                {/* ⏩ 페이징 */}
-                <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
-                    {Array.from({ length: totalPages }, (_, i) => (
+                    {/* 🔍 검색창 + 글쓰기 버튼 한 줄 정렬 */}
+                    <div style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "1.5rem"
+                    }}>
+                        <SearchBar />
                         <button
-                            key={i}
-                            onClick={() => setCurrentPage(i + 1)}
                             style={{
-                                margin: "0 0.25rem",
-                                padding: "0.4rem 0.75rem",
-                                backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
-                                color: currentPage === i + 1 ? "white" : "black",
+                                backgroundColor: "#FFA94D",
+                                color: "#fff",
                                 border: "none",
-                                borderRadius: "4px",
+                                borderRadius: "6px",
+                                padding: "0.5rem 1rem",
+                                fontSize: "0.9rem",
+                                fontWeight: 550,
                                 cursor: "pointer",
+                                marginRight: "0.5rem",
+                                width: "10%"
                             }}
+                            onClick={handleWriteClick}
                         >
-                            {i + 1}
+                            글쓰기
                         </button>
-                    ))}
+                    </div>
+
+                    {/* 📋 게시글 테이블 */}
+                    <table style={{
+                        width: "100%",
+                        borderCollapse: "collapse",
+                        backgroundColor: "#fff",
+                        border: "1px solid #ddd",
+                        borderRadius: "5px",
+                        overflow: "hidden"
+                    }}>
+                        <thead>
+                        <tr style={{ backgroundColor: "#f9f9f9", textAlign: "left" }}>
+                            <th style={{ ...th, width: "40%" }}>제목</th>
+                            <th style={{ ...th, width: "15%" }}>작성자</th>
+                            <th style={{ ...th, width: "15%" }}>작성일</th>
+                            <th style={{ ...th, width: "15%" }}>추천수</th>
+                            <th style={{ ...th, width: "15%" }}>조회수</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currentBoards.map((board) => (
+                            <tr
+                                key={board.boardId}
+                                onClick={() => handleRowClick(board.boardId)}
+                                style={{
+                                    borderTop: "1px solid #eee",
+                                    cursor: "pointer",
+                                    transition: "background 0.2s",
+                                }}
+                                onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#fcddb6")}
+                                onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "white")}
+                            >
+                                <td style={td}>{board.title}</td>
+                                <td style={td}>{board.username}</td>
+                                <td style={td}>{new Date(board.createdAt).toLocaleDateString()}</td>
+                                <td style={td}>{board.likeCount}</td>
+                                <td style={td}>{board.viewCount}</td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+
+                    {/* ⏩ 페이징 */}
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#FFC078" : "#f0f0f0",
+                                    color: currentPage === i + 1 ? "white" : "black",
+                                    border: "none",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## 📌 PR 제목
- `style: 페이지 레이아웃 리사이징 및 반응형 정렬 개선`

---

## ✨ 주요 변경사항
- 커뮤니티 메인 및 게시판 페이지 전체 레이아웃 `max-width` 및 `margin: 0 auto`로 고정
- Wargame, Ranking, Dashboard, Mypage 등 모든 주요 페이지 컨테이너 사이즈 통일 (`max-width: 1200px`)
- Sidebar 포함 레이아웃의 `display: flex`, `gap`, `padding` 값 통일
- Q&A 페이지 하단 정렬 문제 및 미세한 위치 이슈 수정

---

## 🔍 상세 설명
- 기존에는 페이지마다 레이아웃 사이즈와 정렬 기준이 달라 메뉴바 고정처럼 보이지 않음
- 이를 해결하기 위해 모든 페이지의 최상위 wrapper에 동일한 최대 너비와 중앙 정렬 적용
- 반응형 구조도 유지하면서 모바일 환경에서도 자연스럽게 줄어들도록 구성

---

## ✅ 확인 리스트
- [x] 주요 페이지 콘텐츠 정렬 및 메뉴바 위치 일치
- [x] 다크모드 포함 시 스타일 정상 반영
- [x] 페이지 축소 시 레이아웃 깨짐 없는지 확인
- [x] 각 게시판 페이지 상단 설명 영역과 콘텐츠 사이 간격 정렬 확인

---

## 🧪 테스트 결과
- [x] 커뮤니티 메인 페이지 레이아웃 중앙 정렬 확인
- [x] 자유게시판/스터디/문의/Q&A 각각의 페이지 정렬 이상 없음
- [x] Wargame/Ranking/Mypage 대시보드 정렬 확인
- [x] 크롬, 사파리, 파이어폭스에서 화면 축소 시 정상 동작

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 모든 페이지가 동일한 wrapper 스타일을 따르도록 통일했으며 추후 공통 wrapper 컴포넌트로 리팩토링 가능성 있음
