### PR TITLE
feat: implement QnA write form with wargame selector and post creation

### DIFF
--- a/guardians/src/App.tsx
+++ b/guardians/src/App.tsx
@@ -30,6 +30,8 @@ import MypagePage from "./pages/MyPage/MypagePage";
 import MypageInfoCard from "./pages/MyPage/MypageInfoCard";
 import PostsPage from "./pages/MyPage/posts/PostsPage.tsx";
 import Footer from "./components/Footer.tsx";
+import QnaDetailPage from "./pages/community/QnaDetailPage.tsx";
+import QnaWrite from "./pages/community/QnaWrite.tsx";
 
 function App() {
     const location = useLocation();
@@ -109,7 +111,7 @@ function App() {
                     <Route path="/ranking" element={<RankingPage />} />
                     <Route path="/wargame" element={<WargamePage />} />
                     <Route path="/wargame/:id" element={<WargameDetailPage />} />
-                    <Route path="/job" element={<JobPage />} /> {/* 일단 여기 두겠음 */}
+                    <Route path="/job" element={<JobPage />} />
 
                     {/* 💬 커뮤니티 */}
                     <Route path="/community" element={<CommunityPage />} />
@@ -117,6 +119,8 @@ function App() {
                     <Route path="/community/free/write" element={<BoardWrite type="FREE" />} />
                     <Route path="/community/free/:id" element={<FreeBoardDetailPage />} />
                     <Route path="/community/qna" element={<QnaBoardPage />} />
+                    <Route path="/qna/write" element={<QnaWrite />} />
+                    <Route path="/qna/:id" element={<QnaDetailPage />} />
                     <Route path="/community/study" element={<StudyBoardPage />} />
                     <Route path="/community/study/write" element={<BoardWrite type="STUDY" />} />
                     <Route path="/community/study/:id" element={<StudyBoardDetailPage />} />

--- a/guardians/src/components/Header.tsx
+++ b/guardians/src/components/Header.tsx
@@ -71,6 +71,7 @@ function Header() {
                             <a href="/wargame" className={styles.link}>워게임</a>
                             <a href="/ranking" className={styles.link}>랭킹</a>
                             <a href="/community" className={styles.link}>커뮤니티</a>
+                            <a href="/job" className={styles.link}>커리어</a>
                             {isLoggedIn && (
                                 <a href="/dashboard" className={styles.link}>대시보드</a>
                             )}

--- a/guardians/src/pages/community/QnaBoardPage.tsx
+++ b/guardians/src/pages/community/QnaBoardPage.tsx
@@ -1,4 +1,5 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom"; // ✅ 추가
 import Sidebar from "./components/Sidebar";
 import SearchBar from "./components/SearchBar";
 import viewIcon from "../../assets/view.png";
@@ -18,6 +19,7 @@ type QnaPost = {
 const QnaBoardPage = () => {
     const [posts, setPosts] = useState<QnaPost[]>([]);
     const [currentPage, setCurrentPage] = useState(1);
+    const navigate = useNavigate(); // ✅ 추가
     const postsPerPage = 10;
 
     useEffect(() => {
@@ -96,7 +98,7 @@ const QnaBoardPage = () => {
                                 marginRight: "0.5rem",
                                 width: "10%",
                             }}
-                            onClick={() => alert("글쓰기 클릭!")}
+                            onClick={() => navigate("/qna/write")} // 🔥 여기도 수정 가능
                         >
                             질문하기
                         </button>
@@ -115,7 +117,7 @@ const QnaBoardPage = () => {
                                     cursor: "pointer",
                                     transition: "box-shadow 0.2s",
                                 }}
-                                onClick={() => alert(`Q&A 상세로 이동 ID: ${post.id}`)}
+                                onClick={() => navigate(`/qna/${post.id}`)} // ✅ 요기 변경!
                                 onMouseOver={(e) => (e.currentTarget.style.boxShadow = "0 6px 16px rgba(0,0,0,0.1)")}
                                 onMouseOut={(e) => (e.currentTarget.style.boxShadow = "0 4px 10px rgba(0, 0, 0, 0.04)")}
                             >
@@ -162,8 +164,8 @@ const QnaBoardPage = () => {
                                             borderRadius: "999px",
                                         }}
                                     >
-                                    {post.answerCount && post.answerCount > 0 ? "답변완료" : "미답변"}
-                                </span>
+                                        {post.answerCount && post.answerCount > 0 ? "답변완료" : "미답변"}
+                                    </span>
                                 </div>
                             </div>
                         ))}

--- a/guardians/src/pages/community/QnaDetailPage.tsx
+++ b/guardians/src/pages/community/QnaDetailPage.tsx
@@ -1,0 +1,254 @@
+import {Link, useNavigate, useParams} from 'react-router-dom';
+import {useEffect, useState} from 'react';
+import axios from 'axios';
+import styles from './components/QnaDetailPage.module.css'
+
+interface Qna {
+    id: number;
+    title: string;
+    content: string;
+    username: string;
+    createdAt: string;
+    viewCount: number;
+    userId: string;
+    wargameId: number;
+    wargameTitle: string;
+}
+
+interface Answer {
+    id: number;
+    content: string;
+    username: string;
+    createdAt: string;
+    userId: string;
+}
+
+const QnaDetailPage = () => {
+    const {id} = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const [qna, setQna] = useState<Qna | null>(null);
+    const [answers, setAnswers] = useState<Answer[]>([]);
+    const [newAnswer, setNewAnswer] = useState('');
+    const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+    // 답변 수정 상태
+    const [editingAnswerId, setEditingAnswerId] = useState<number | null>(null);
+    const [editingAnswerContent, setEditingAnswerContent] = useState('');
+
+    // 질문 수정 상태
+    const [editingQuestion, setEditingQuestion] = useState(false);
+    const [editedTitle, setEditedTitle] = useState('');
+    const [editedContent, setEditedContent] = useState('');
+
+    useEffect(() => {
+        if (!id) return;
+        fetchQna();
+        fetchAnswers();
+        checkLogin();
+    }, [id]);
+
+    const fetchQna = async () => {
+        const res = await axios.get(`/api/qna/questions/${id}`, {withCredentials: true});
+        const data = res.data.result.data;
+        setQna(data);
+        setEditedTitle(data.title);
+        setEditedContent(data.content);
+    };
+
+    const fetchAnswers = async () => {
+        const res = await axios.get(`/api/qna/answers/${id}`, {withCredentials: true});
+        setAnswers(res.data.result.data);
+    };
+
+    const checkLogin = async () => {
+        try {
+            const res = await axios.get("/api/users/me", {withCredentials: true});
+            setSessionUserId(String(res.data.result.data.id));
+            setIsLoggedIn(true);
+        } catch {
+            setIsLoggedIn(false);
+        }
+    };
+
+    const handleDeleteQuestion = async () => {
+        if (!window.confirm('질문을 삭제할까요?')) return;
+        await axios.delete(`/api/qna/questions/${id}?userId=${sessionUserId}`, {withCredentials: true});
+        alert('삭제 완료!');
+        navigate('/community/qna');
+    };
+
+    const handleUpdateQuestion = async () => {
+        await axios.patch(`/api/qna/questions/${id}?userId=${sessionUserId}`, {
+            title: editedTitle,
+            content: editedContent
+        }, {withCredentials: true});
+        setEditingQuestion(false);
+        fetchQna();
+    };
+
+    const handleAnswerSubmit = async () => {
+        if (!newAnswer.trim()) return;
+        await axios.post(`/api/qna/answers?userId=${sessionUserId}`, {
+            content: newAnswer,
+            questionId: id
+        }, {withCredentials: true});
+        setNewAnswer('');
+        fetchAnswers();
+    };
+
+    const startEditAnswer = (id: number, content: string) => {
+        setEditingAnswerId(id);
+        setEditingAnswerContent(content);
+    };
+
+    const confirmEditAnswer = async (answerId: number) => {
+        if (!editingAnswerContent.trim()) return;
+        await axios.patch(`/api/qna/answers/${answerId}?userId=${Number(sessionUserId)}`, {
+            content: editingAnswerContent
+        }, {withCredentials: true});
+        setEditingAnswerId(null);
+        setEditingAnswerContent('');
+        fetchAnswers();
+    };
+
+    const deleteAnswer = async (answerId: number) => {
+        if (!window.confirm("답변을 삭제할까요?")) return;
+        await axios.delete(`/api/qna/answers/${answerId}?userId=${sessionUserId}`, {withCredentials: true});
+        fetchAnswers();
+    };
+
+    if (!qna) return <div style={{textAlign: 'center', marginTop: '2rem'}}>로딩 중...</div>;
+
+    const isAuthor = sessionUserId === String(qna.userId);
+
+    return (
+        <div className={styles.pageWrapper}>
+            <div className={styles.mainContent}>
+                <div className={styles.topBar}>
+                    <button className={styles.backBtn} onClick={() => navigate(-1)}>← 뒤로가기</button>
+                    {isLoggedIn && isAuthor && (
+                        <>
+                            {editingQuestion ? (
+                                <button className={styles.deleteBtn} onClick={handleUpdateQuestion}>저장</button>
+                            ) : (
+                                <>
+                                    <button className={styles.deleteBtn} onClick={() => setEditingQuestion(true)}>수정하기
+                                    </button>
+                                    <button className={styles.deleteBtn} onClick={handleDeleteQuestion}>삭제하기</button>
+                                </>
+                            )}
+                        </>
+                    )}
+                </div>
+
+                <div className={styles.leftColumn}>
+                    <div className={styles["title-row"]}>
+                        <Link
+                            to={`/wargame/${qna.wargameId}`}
+                            style={{
+                                display: "inline-block",
+                                marginBottom: "0.75rem",
+                                fontWeight: 600,
+                                fontSize: "1.05rem",
+                                color: "#FFA94D",
+                                textDecoration: "none"
+                            }}
+                        >
+                            [{qna.wargameTitle}]
+                        </Link>
+                        <div className={styles["header-card"]}>
+                            <div className={styles["title-row"]}>
+                                {editingQuestion ? (
+                                    <input
+                                        value={editedTitle}
+                                        onChange={(e) => setEditedTitle(e.target.value)}
+                                        className={styles.titleInput}
+                                    />
+                                ) : (
+                                    <h1 className={styles.title}>{qna.title}</h1>
+                                )}
+                            </div>
+                            <div className={styles.meta}>
+                                <span>✍ 작성자: {qna.username}</span>
+                                <span>🕒 작성일: {new Date(qna.createdAt).toLocaleDateString()}</span>
+                                <span>👀 조회 {qna.viewCount}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div className={styles.plainContent}>
+                        {editingQuestion ? (
+                            <textarea
+                                value={editedContent}
+                                onChange={(e) => setEditedContent(e.target.value)}
+                                className={styles.editContentArea}
+                                rows={10}
+                            />
+                        ) : (
+                            qna.content
+                        )}
+                    </div>
+
+                    {/* 답변 영역 */}
+                    <div className={styles.commentSection}>
+                        <h2 className={styles.commentTitle}>답변 {answers.length}</h2>
+
+                        {isLoggedIn && (
+                            <div className={styles.commentForm}>
+                                <textarea
+                                    className={styles.commentTextarea}
+                                    value={newAnswer}
+                                    onChange={(e) => setNewAnswer(e.target.value)}
+                                    placeholder="답변을 입력하세요"
+                                />
+                                <div style={{display: "flex", justifyContent: "flex-end"}}>
+                                    <button className={styles.submitBtn} onClick={handleAnswerSubmit}>등록</button>
+                                </div>
+                            </div>
+                        )}
+
+                        <ul className={styles.commentList}>
+                            {answers.map(answer => (
+                                <li key={answer.id} className={styles.commentItem}>
+                                    <div className={styles.commentHeader}>
+                                        <div className={styles.username}>{answer.username}</div>
+                                        <small className={styles.createdAt}>
+                                            {new Date(answer.createdAt).toLocaleDateString()}
+                                        </small>
+                                    </div>
+                                    {editingAnswerId === answer.id ? (
+                                        <>
+                                            <textarea
+                                                className={styles.commentTextarea}
+                                                value={editingAnswerContent}
+                                                onChange={(e) => setEditingAnswerContent(e.target.value)}
+                                            />
+                                            <div className={styles.reviewActionBtns}>
+                                                <button onClick={() => confirmEditAnswer(answer.id)}>저장</button>
+                                                <button onClick={() => setEditingAnswerId(null)}>취소</button>
+                                            </div>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <p className={styles.commentContent}>{answer.content}</p>
+                                            {isLoggedIn && String(answer.userId) === sessionUserId && (
+                                                <div className={styles.reviewActionBtns}>
+                                                    <button
+                                                        onClick={() => startEditAnswer(answer.id, answer.content)}>수정
+                                                    </button>
+                                                    <button onClick={() => deleteAnswer(answer.id)}>삭제</button>
+                                                </div>
+                                            )}
+                                        </>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default QnaDetailPage;

--- a/guardians/src/pages/community/QnaWrite.tsx
+++ b/guardians/src/pages/community/QnaWrite.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import styles from "./BoardWrite.module.css";
+
+type Wargame = {
+    id: number;
+    title: string;
+};
+
+const QnaWrite = () => {
+    const [title, setTitle] = useState('');
+    const [content, setContent] = useState('');
+    const [wargames, setWargames] = useState<Wargame[]>([]);
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<Wargame | null>(null);
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        axios.get("/api/wargames")
+            .then(res => {
+                const data = res.data.result.data;
+                setWargames(data);
+            })
+            .catch(err => {
+                console.error("워게임 목록 불러오기 실패", err);
+            });
+    }, []);
+
+    const filtered = wargames.filter(w =>
+        w.title?.toLowerCase().includes(search.toLowerCase())
+    );
+
+    const handleSelect = (w: Wargame) => {
+        setSelected(w);
+        setSearch(w.title);
+        setShowDropdown(false);
+    };
+
+    const handleSubmit = () => {
+        if (!title || !content || !selected) {
+            alert("제목, 내용, 워게임을 모두 입력해주세요.");
+            return;
+        }
+
+        axios.post(`/api/qna/questions`, {
+            title,
+            content,
+            wargameId: selected.id,
+        }, { withCredentials: true })
+            .then(() => {
+                alert("질문 등록 완료!");
+                navigate("/community/qna");
+            })
+            .catch(err => {
+                console.error('질문 등록 실패', err);
+                alert('질문 등록에 실패했습니다.');
+            });
+    };
+
+    const handleCancel = () => {
+        navigate("/community/qna");
+    };
+
+    return (
+        <div className={styles.wrapper} style={{ position: "relative" }}>
+            <h2 className={styles.pageTitle}>질문 작성</h2>
+
+            <input
+                type="text"
+                placeholder="워게임 제목 검색"
+                value={search}
+                onChange={(e) => {
+                    setSearch(e.target.value);
+                    setShowDropdown(true);
+                }}
+                onFocus={() => setShowDropdown(true)}
+                className={styles.input}
+            />
+
+            {showDropdown && search && (
+                <ul style={{
+                    listStyle: "none",
+                    padding: 0,
+                    border: "1px solid #ccc",
+                    borderRadius: "6px",
+                    marginTop: "0.5rem",
+                    maxHeight: "150px",
+                    overflowY: "auto",
+                    background: "#fff",
+                    position: "absolute",
+                    zIndex: 10,
+                    width: "100%",
+                }}>
+                    {filtered.length > 0 ? (
+                        filtered.map(w => (
+                            <li
+                                key={w.id}
+                                onClick={() => handleSelect(w)}
+                                style={{
+                                    padding: "0.6rem 1rem",
+                                    cursor: "pointer",
+                                    borderBottom: "1px solid #eee",
+                                    backgroundColor: selected?.id === w.id ? "#fff7ed" : "#fff"
+                                }}
+                            >
+                                {w.title}
+                            </li>
+                        ))
+                    ) : (
+                        <li style={{ padding: "0.6rem 1rem", color: "#999" }}>
+                            일치하는 워게임이 없습니다.
+                        </li>
+                    )}
+                </ul>
+            )}
+
+            {selected && (
+                <div style={{ marginTop: "0.5rem", fontSize: "0.9rem", color: "#666" }}>
+                    선택된 워게임: <strong>{selected.title}</strong>
+                </div>
+            )}
+
+            <input
+                type="text"
+                placeholder="제목을 입력하세요"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className={styles.input}
+            />
+
+            <textarea
+                placeholder="내용을 입력하세요"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                className={styles.textarea}
+            />
+
+            <div className={styles.btnGroup}>
+                <button onClick={handleSubmit} className={styles.submitBtn}>등록</button>
+                <button onClick={handleCancel} className={styles.cancelBtn}>취소</button>
+            </div>
+        </div>
+    );
+};
+
+export default QnaWrite;

--- a/guardians/src/pages/community/components/QnaDetailPage.module.css
+++ b/guardians/src/pages/community/components/QnaDetailPage.module.css
@@ -1,0 +1,226 @@
+.pageWrapper {
+    display: flex;
+    justify-content: center;
+    padding: 4rem 2rem;
+    background-color: #fafafa;
+}
+
+.mainContent {
+    width: 100%;
+    max-width: 900px;
+}
+
+.leftColumn {
+    width: 100%;
+}
+
+.headerCard {
+    background-color: #fffefc;
+    border: 1px solid #ffe0b3;
+    border-radius: 1rem;
+    padding: 1.5rem 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.wargameLink {
+    display: inline-block;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: #ffa94d;
+    text-decoration: none;
+}
+
+.wargameLink:hover {
+    text-decoration: underline;
+}
+
+.titleRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+}
+
+.titleInput {
+    font-size: 1.5rem;
+    font-weight: bold;
+    width: 100%;
+    border: 1px solid #ccc;
+    border-radius: 0.5rem;
+    padding: 0.6rem 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.meta {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.plainContent {
+    margin: 2rem 1rem;
+    font-size: 1rem;
+    line-height: 1.8;
+    color: #333;
+    min-height: 10rem;
+    white-space: pre-line;
+}
+
+.editContentArea {
+    width: 100%;
+    min-height: 200px;
+    font-size: 1rem;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid #ccc;
+    resize: vertical;
+}
+
+.topBar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.backBtn {
+    background: none;
+    border: none;
+    color: #444;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    padding-left: 0.3rem;
+}
+
+.backBtn:hover {
+    text-decoration: underline;
+}
+
+.deleteBtn {
+    background: none;
+    border: none;
+    color: #d33;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0.3rem 0.8rem;
+}
+
+.deleteBtn:hover {
+    text-decoration: underline;
+}
+
+/* 댓글(답변) 영역 */
+.commentSection {
+    margin-top: 3rem;
+}
+
+.commentTitle {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid #ffa94d;
+    padding-bottom: 0.4rem;
+    color: #333;
+}
+
+.commentForm {
+    margin-bottom: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.commentTextarea {
+    width: 100%;
+    height: 90px;
+    padding: 0.75rem;
+    font-size: 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid #ccc;
+    resize: none;
+}
+
+.submitBtn {
+    background-color: #ffa94d;
+    border: none;
+    padding: 0.5rem 1.2rem;
+    border-radius: 6px;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+    align-self: flex-end;
+}
+
+.commentList {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+}
+
+.commentItem {
+    background-color: #fffefc;
+    border: 1px solid #ffe0b3;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #333;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.commentHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.username {
+    font-weight: 600;
+}
+
+.createdAt {
+    color: #666;
+}
+
+.commentContent {
+    white-space: pre-wrap;
+    font-size: 1rem;
+    color: #333;
+    margin: 0;
+}
+
+.reviewActionBtns {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 2rem;
+}
+
+.reviewActionBtns button {
+    font-size: 0.8rem;
+    background-color: transparent;
+    border: 1px solid #ffa94d;
+    color: #ffa94d;
+    padding: 0.3rem 0.8rem;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: 0.2s;
+}
+
+.reviewActionBtns button:hover {
+    background-color: #fff7ed;
+}


### PR DESCRIPTION
## 📌 PR 제목
- feat: implement QnA write form with wargame selector and post creation

---

## ✨ 주요 변경사항
- QnA 질문 작성 폼(`QnaWrite`) 추가
- 워게임 제목 검색 및 선택 기능 구현
- 질문 등록 POST API 연동 (`/api/qna/questions`)
- 등록 성공 시 QnA 게시판으로 이동
- 기본 유효성 검사 (제목/내용/워게임 미입력 시 alert)

---

## 🔍 상세 설명
- 사용자들이 워게임 관련 질문을 올릴 수 있도록 하기 위해 질문 작성 기능이 필요함
- 작성 폼에서 워게임 제목을 검색 후 선택 → 제목 및 내용을 작성 → 등록 버튼 클릭 시 서버로 전송
- `wargameId`, `title`, `content`을 포함한 JSON 데이터를 API에 POST
- 로그인 세션 기반으로 백엔드에서 `userId` 추출하도록 변경 예정

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 유효성 검사(alert) 정상 작동
- [x] 서버 API 연동 및 등록 성공 시 페이지 이동
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] 질문 작성 → 등록 완료 → `/community/qna`로 이동 확인
- [x] 워게임 선택 없이 등록 시 alert 작동 확인
- [x] API 서버와 세션 연동 정상 작동 (`withCredentials: true` 사용)

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 백엔드에서 `@RequestParam Long userId` 구조는 추후 세션에서 추출하는 방식으로 개선 필요
- 추후 등록 성공 후 토스트 메시지 또는 모달 방식 적용 고려
