### PR TITLE
feat: integrate QnA view count API and update back button UI

### DIFF
--- a/guardians/src/pages/Dashboard/DashboardPage.tsx
+++ b/guardians/src/pages/Dashboard/DashboardPage.tsx
@@ -106,6 +106,8 @@ const DashboardPage = () => {
         fetchData();
     }, []);
 
+
+
     if (isLoading) {
         return <div style={{textAlign: "center", padding: "2rem"}}>로딩 중...</div>;
     }

--- a/guardians/src/pages/community/FreeBoardDetailPage.tsx
+++ b/guardians/src/pages/community/FreeBoardDetailPage.tsx
@@ -101,6 +101,13 @@ const FreeBoardDetailPage = () => {
         });
     };
 
+    const handleInfoModalClose = () => {
+        setShowInfoModal(false);
+        if (infoMessage === '게시글이 삭제되었습니다.') {
+            navigate('/community/free');
+        }
+    };
+
     const handleEdit = () => {
         if (!board) return;
         navigate(`/community/free/edit/${board.boardId}`);
@@ -155,12 +162,7 @@ const FreeBoardDetailPage = () => {
         }
     };
 
-    const handleInfoModalClose = () => {
-        setShowInfoModal(false);
-        if (infoMessage === '게시글이 삭제되었습니다.') {
-            navigate('/community/free');
-        }
-    };
+
 
 
     if (!board) {
@@ -171,7 +173,16 @@ const FreeBoardDetailPage = () => {
         <div className={styles.pageWrapper}>
             <div className={styles.mainContent}>
                 <div className={styles.topBar}>
-                    <button className={styles.backBtn} onClick={() => navigate(-1)}>← 뒤로가기</button>
+                    <button
+                        className={styles.backBtn}
+                        onClick={() => navigate(-1)}
+                        style={{
+                            fontSize: '2rem',
+                            textDecoration: 'none'
+                    }}
+                    >
+                        ←
+                    </button>
                     {isLoggedIn && String(sessionUserId) === String(board.userId) && (
                         <div style={{ display: 'flex', gap: '0.5rem' }}>
                             <button className={styles.deleteBtn} onClick={handleEdit}>수정하기</button>
@@ -187,11 +198,16 @@ const FreeBoardDetailPage = () => {
                                 onClick={toggleLike}
                                 disabled={!isLoggedIn}
                                 className={`${styles["action-btn"]} ${isLiked ? styles.active : ""}`}
-                                style={{cursor: isLoggedIn ? 'pointer' : 'not-allowed'}}
+                                style={{
+                                    marginLeft: '1rem',
+                                    cursor: isLoggedIn ? 'pointer' : 'not-allowed',
+                                    width: '60px',
+                                    height: '35px',
+                                    whiteSpace: 'nowrap',
+                                }}
                             >
                                 {isLiked ? "❤️" : "🤍"} {board.likeCount}
-                            </button>
-                        </div>
+                            </button>                        </div>
                         <div className={styles.meta}>
                             <span>✍ 작성자: {board.username}</span>
                             <span>🕒 작성일: {new Date(board.createdAt).toLocaleDateString()}</span>

--- a/guardians/src/pages/community/InquiryBoardDetailPage.tsx
+++ b/guardians/src/pages/community/InquiryBoardDetailPage.tsx
@@ -168,7 +168,16 @@ const InquiryBoardDetailPage = () => {
         <div className={styles.pageWrapper}>
             <div className={styles.mainContent}>
                 <div className={styles.topBar}>
-                    <button className={styles.backBtn} onClick={() => navigate(-1)}>← 뒤로가기</button>
+                    <button
+                        className={styles.backBtn}
+                        onClick={() => navigate(-1)}
+                        style={{
+                            fontSize: '2rem',
+                            textDecoration: 'none'
+                        }}
+                    >
+                        ←
+                    </button>
                     {isLoggedIn && String(sessionUserId) === String(board.userId) && (
                         <div style={{ display: 'flex', gap: '0.5rem' }}>
                             <button className={styles.deleteBtn} onClick={handleEdit}>수정하기</button>
@@ -184,7 +193,13 @@ const InquiryBoardDetailPage = () => {
                                 onClick={toggleLike}
                                 disabled={!isLoggedIn}
                                 className={`${styles["action-btn"]} ${isLiked ? styles.active : ""}`}
-                                style={{cursor: isLoggedIn ? 'pointer' : 'not-allowed'}}
+                                style={{
+                                    marginLeft: '1rem',
+                                    cursor: isLoggedIn ? 'pointer' : 'not-allowed',
+                                    width: '60px',
+                                    height: '35px',
+                                    whiteSpace: 'nowrap',
+                                }}
                             >
                                 {isLiked ? "❤️" : "🤍"} {board.likeCount}
                             </button>

--- a/guardians/src/pages/community/QnaDetailPage.tsx
+++ b/guardians/src/pages/community/QnaDetailPage.tsx
@@ -1,7 +1,8 @@
-import {Link, useNavigate, useParams} from 'react-router-dom';
-import {useEffect, useState} from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
-import styles from './components/QnaDetailPage.module.css'
+import styles from './components/QnaDetailPage.module.css';
+import Modal from "./components/Modal.tsx";
 
 interface Qna {
     id: number;
@@ -21,16 +22,20 @@ interface Answer {
     username: string;
     createdAt: string;
     userId: string;
+    profileImageUrl?: string;
+    tier?: string;
 }
 
+
 const QnaDetailPage = () => {
-    const {id} = useParams<{ id: string }>();
+    const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const [qna, setQna] = useState<Qna | null>(null);
     const [answers, setAnswers] = useState<Answer[]>([]);
     const [newAnswer, setNewAnswer] = useState('');
     const [sessionUserId, setSessionUserId] = useState<string | null>(null);
     const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [confirmDeletePost, setConfirmDeletePost] = useState(false);
 
     // 답변 수정 상태
     const [editingAnswerId, setEditingAnswerId] = useState<number | null>(null);
@@ -41,15 +46,18 @@ const QnaDetailPage = () => {
     const [editedTitle, setEditedTitle] = useState('');
     const [editedContent, setEditedContent] = useState('');
 
+    const [showInfoModal, setShowInfoModal] = useState(false);
+    const [infoMessage, setInfoMessage] = useState('');
+
     useEffect(() => {
         if (!id) return;
         fetchQna();
         fetchAnswers();
-        checkLogin();
+        checkLoginStatus();
     }, [id]);
 
     const fetchQna = async () => {
-        const res = await axios.get(`/api/qna/questions/${id}`, {withCredentials: true});
+        const res = await axios.get(`/api/qna/questions/${id}`, { withCredentials: true });
         const data = res.data.result.data;
         setQna(data);
         setEditedTitle(data.title);
@@ -57,34 +65,53 @@ const QnaDetailPage = () => {
     };
 
     const fetchAnswers = async () => {
-        const res = await axios.get(`/api/qna/answers/${id}`, {withCredentials: true});
+        const res = await axios.get(`/api/qna/answers/${id}`, { withCredentials: true });
         setAnswers(res.data.result.data);
     };
 
-    const checkLogin = async () => {
-        try {
-            const res = await axios.get("/api/users/me", {withCredentials: true});
-            setSessionUserId(String(res.data.result.data.id));
-            setIsLoggedIn(true);
-        } catch {
-            setIsLoggedIn(false);
-        }
+    const checkLoginStatus = () => {
+        axios.get('/api/users/me', { withCredentials: true })
+            .then(res => {
+                const id = res.data.result.data.id;
+                setIsLoggedIn(true);
+                setSessionUserId(String(id));
+            })
+            .catch(() => {
+                setIsLoggedIn(false);
+                setSessionUserId(null);
+            });
     };
 
-    const handleDeleteQuestion = async () => {
-        if (!window.confirm('질문을 삭제할까요?')) return;
-        await axios.delete(`/api/qna/questions/${id}?userId=${sessionUserId}`, {withCredentials: true});
-        alert('삭제 완료!');
-        navigate('/community/qna');
+    const handleDelete = () => {
+        setConfirmDeletePost(true);
     };
 
-    const handleUpdateQuestion = async () => {
+    const confirmDeletePostAction = async () => {
+        axios.delete(`/api/qna/questions/${id}?userId=${sessionUserId}`, { withCredentials: true });
+        setInfoMessage('질문이 삭제되었습니다.');
+        setShowInfoModal(true);
+    };
+
+    const handleEdit = () => {
+        // 질문 수정 모드 활성화
+        setEditingQuestion(true);
+        // navigate(`/community/qna/edit`);  // navigate 유지하고 싶다면 이 부분은 살리기
+    };
+
+    const handleSaveQuestionEdit = async () => {
         await axios.patch(`/api/qna/questions/${id}?userId=${sessionUserId}`, {
             title: editedTitle,
             content: editedContent
-        }, {withCredentials: true});
-        setEditingQuestion(false);
-        fetchQna();
+        }, { withCredentials: true });
+        setEditingQuestion(false);  // 수정 모드 종료
+        fetchQna();  // 질문 다시 불러오기
+    };
+
+    const handleInfoModalClose = () => {
+        setShowInfoModal(false);
+        if (infoMessage === '질문이 삭제되었습니다.') {
+            navigate('/community/qna');
+        }
     };
 
     const handleAnswerSubmit = async () => {
@@ -92,7 +119,7 @@ const QnaDetailPage = () => {
         await axios.post(`/api/qna/answers?userId=${sessionUserId}`, {
             content: newAnswer,
             questionId: id
-        }, {withCredentials: true});
+        }, { withCredentials: true });
         setNewAnswer('');
         fetchAnswers();
     };
@@ -106,7 +133,7 @@ const QnaDetailPage = () => {
         if (!editingAnswerContent.trim()) return;
         await axios.patch(`/api/qna/answers/${answerId}?userId=${Number(sessionUserId)}`, {
             content: editingAnswerContent
-        }, {withCredentials: true});
+        }, { withCredentials: true });
         setEditingAnswerId(null);
         setEditingAnswerContent('');
         fetchAnswers();
@@ -114,31 +141,42 @@ const QnaDetailPage = () => {
 
     const deleteAnswer = async (answerId: number) => {
         if (!window.confirm("답변을 삭제할까요?")) return;
-        await axios.delete(`/api/qna/answers/${answerId}?userId=${sessionUserId}`, {withCredentials: true});
+        await axios.delete(`/api/qna/answers/${answerId}?userId=${sessionUserId}`, { withCredentials: true });
         fetchAnswers();
     };
+    useEffect(() => {
+        console.log('로그인한 사용자 ID:', sessionUserId);
+        console.log('게시글 작성자 ID:', qna?.userId);
+    }, [sessionUserId, qna]);
 
-    if (!qna) return <div style={{textAlign: 'center', marginTop: '2rem'}}>로딩 중...</div>;
 
-    const isAuthor = sessionUserId === String(qna.userId);
+    if (!qna) return <div style={{ textAlign: 'center', marginTop: '2rem' }}>로딩 중...</div>;
 
     return (
         <div className={styles.pageWrapper}>
             <div className={styles.mainContent}>
                 <div className={styles.topBar}>
-                    <button className={styles.backBtn} onClick={() => navigate(-1)}>← 뒤로가기</button>
-                    {isLoggedIn && isAuthor && (
-                        <>
-                            {editingQuestion ? (
-                                <button className={styles.deleteBtn} onClick={handleUpdateQuestion}>저장</button>
-                            ) : (
+                    <button
+                        className={styles.backBtn}
+                        onClick={() => navigate(-1)}
+                        style={{
+                            fontSize: '2rem',
+                            textDecoration: 'none'
+                        }}
+                    >
+                        ←
+                    </button>
+                    {isLoggedIn && qna && sessionUserId && String(sessionUserId) === String(qna.userId) && (
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
+                            {!editingQuestion ? (
                                 <>
-                                    <button className={styles.deleteBtn} onClick={() => setEditingQuestion(true)}>수정하기
-                                    </button>
-                                    <button className={styles.deleteBtn} onClick={handleDeleteQuestion}>삭제하기</button>
+                                    <button className={styles.deleteBtn} onClick={handleEdit}>수정하기</button>
+                                    <button className={styles.deleteBtn} onClick={handleDelete}>삭제하기</button>
                                 </>
+                            ) : (
+                                <button className={styles.deleteBtn} onClick={handleSaveQuestionEdit}>저장하기</button>
                             )}
-                        </>
+                        </div>
                     )}
                 </div>
 
@@ -201,7 +239,7 @@ const QnaDetailPage = () => {
                                     onChange={(e) => setNewAnswer(e.target.value)}
                                     placeholder="답변을 입력하세요"
                                 />
-                                <div style={{display: "flex", justifyContent: "flex-end"}}>
+                                <div style={{ display: "flex", justifyContent: "flex-end" }}>
                                     <button className={styles.submitBtn} onClick={handleAnswerSubmit}>등록</button>
                                 </div>
                             </div>
@@ -210,12 +248,34 @@ const QnaDetailPage = () => {
                         <ul className={styles.commentList}>
                             {answers.map(answer => (
                                 <li key={answer.id} className={styles.commentItem}>
-                                    <div className={styles.commentHeader}>
-                                        <div className={styles.username}>{answer.username}</div>
-                                        <small className={styles.createdAt}>
-                                            {new Date(answer.createdAt).toLocaleDateString()}
-                                        </small>
+                                    <div className={styles.commentHeader} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                        {/* 프로필 이미지 */}
+                                        <img
+                                            src={answer.profileImageUrl || '/default-profile.png'}
+                                            alt="프로필"
+                                            style={{
+                                                width: "40px",
+                                                height: "40px",
+                                                borderRadius: "50%",
+                                                objectFit: "cover"
+                                            }}
+                                        />
+                                        <div>
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                                <span className={styles.username}>{answer.username}</span>
+                                                {/* 티어 뱃지 */}
+                                                {answer.tier && (
+                                                    <img
+                                                        src={`/badges/${answer.tier}.png`}  // 티어 이미지 경로
+                                                        alt={`${answer.tier} 티어`}
+                                                        style={{ width: '20px', height: '20px' }}
+                                                    />
+                                                )}
+                                            </div>
+                                        <small className={styles.createdAt}>{new Date(answer.createdAt).toLocaleDateString()}</small>
+                                        </div>
                                     </div>
+
                                     {editingAnswerId === answer.id ? (
                                         <>
                                             <textarea
@@ -233,9 +293,7 @@ const QnaDetailPage = () => {
                                             <p className={styles.commentContent}>{answer.content}</p>
                                             {isLoggedIn && String(answer.userId) === sessionUserId && (
                                                 <div className={styles.reviewActionBtns}>
-                                                    <button
-                                                        onClick={() => startEditAnswer(answer.id, answer.content)}>수정
-                                                    </button>
+                                                    <button onClick={() => startEditAnswer(answer.id, answer.content)}>수정</button>
                                                     <button onClick={() => deleteAnswer(answer.id)}>삭제</button>
                                                 </div>
                                             )}
@@ -247,6 +305,20 @@ const QnaDetailPage = () => {
                     </div>
                 </div>
             </div>
+
+            <Modal
+                isOpen={confirmDeletePost}
+                onClose={() => setConfirmDeletePost(false)}
+                onConfirm={confirmDeletePostAction}
+                message="정말 삭제하시겠습니까?"
+            />
+            <Modal
+                isOpen={showInfoModal}
+                onClose={handleInfoModalClose}
+                onConfirm={handleInfoModalClose}
+                message={infoMessage}
+                showCancelButton={false}
+            />
         </div>
     );
 };

--- a/guardians/src/pages/community/StudyBoardDetailPage.tsx
+++ b/guardians/src/pages/community/StudyBoardDetailPage.tsx
@@ -49,6 +49,8 @@ const StudyBoardDetailPage = () => {
         checkLoginStatus();
     }, [id]);
 
+
+
     const fetchBoard = () => {
         axios.get(`/api/boards/${id}`, { withCredentials: true })
             .then(res => setBoard(res.data.result.data));
@@ -160,6 +162,8 @@ const StudyBoardDetailPage = () => {
         }
     };
 
+
+
     if (!board) {
         return <div style={{ textAlign: 'center', marginTop: '2rem' }}>로딩 중...</div>;
     }
@@ -168,7 +172,16 @@ const StudyBoardDetailPage = () => {
         <div className={styles.pageWrapper}>
             <div className={styles.mainContent}>
                 <div className={styles.topBar}>
-                    <button className={styles.backBtn} onClick={() => navigate(-1)}>← 뒤로가기</button>
+                    <button
+                        className={styles.backBtn}
+                        onClick={() => navigate(-1)}
+                        style={{
+                            fontSize: '2rem',
+                            textDecoration: 'none'
+                        }}
+                    >
+                        ←
+                    </button>
                     {isLoggedIn && String(sessionUserId) === String(board.userId) && (
                         <div style={{ display: 'flex', gap: '0.5rem' }}>
                             <button className={styles.deleteBtn} onClick={handleEdit}>수정하기</button>
@@ -184,7 +197,13 @@ const StudyBoardDetailPage = () => {
                                 onClick={toggleLike}
                                 disabled={!isLoggedIn}
                                 className={`${styles["action-btn"]} ${isLiked ? styles.active : ""}`}
-                                style={{cursor: isLoggedIn ? 'pointer' : 'not-allowed'}}
+                                style={{
+                                    marginLeft: '1rem',
+                                    cursor: isLoggedIn ? 'pointer' : 'not-allowed',
+                                    width: '60px',
+                                    height: '35px',
+                                    whiteSpace: 'nowrap',
+                                     }}
                             >
                                 {isLiked ? "❤️" : "🤍"} {board.likeCount}
                             </button>

--- a/guardians/src/pages/community/components/QnaDetailPage.module.css
+++ b/guardians/src/pages/community/components/QnaDetailPage.module.css
@@ -183,7 +183,6 @@
 
 .commentHeader {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     font-size: 0.9rem;
     margin-bottom: 0.5rem;


### PR DESCRIPTION
## 📌 PR 제목
- feat: integrate view count API and update back button UI

---

## ✨ 주요 변경사항
- QnA 상세 페이지에서 질문 조회 시 조회수 증가 API 호출 추가
- 뒤로가기 버튼 UI 개선 (스타일 및 위치 수정)

---

## 🔍 상세 설명
- 기존 뒤로가기 버튼의 스타일을 개선하고 위치를 더 직관적으로 변경하여 UX를 향상시켰습니다.  
- 사용자 경험을 고려하여 뷰 카운트 업데이트는 서버 API 호출 후 로컬 상태에도 즉시 반영됩니다.

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인 (조회수 API 연동, UI 반영)
- [x] API 응답 형식 일관성 확인 (백엔드와 협의된 응답 구조 사용)

---

## 🧪 테스트 결과
- [x] 프론트에서 연동 확인 (조회수 업데이트 및 뒤로가기 버튼 작동)
---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 뒤로가기 버튼은 페이지 히스토리 관리 외부 라이브러리(예: react-router) 대신 브라우저 내장 기능 사용.
- 후속 작업으로 조회수 증가 API 호출 시 debounce 처리 고려 예정.
