### PR TITLE
feat : Implement dashboard page with normalized score visualization

### DIFF
--- a/guardians/package-lock.json
+++ b/guardians/package-lock.json
@@ -13,6 +13,7 @@
         "latest": "^0.2.0",
         "pretendard": "^1.3.9",
         "react": "^19.0.0",
+        "react-calendar": "^5.1.0",
         "react-circular-progressbar": "^2.2.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -1893,6 +1894,14 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2987,6 +2996,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3362,6 +3382,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3369,6 +3400,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/memoize-one": {
@@ -3420,6 +3466,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minimatch": {
@@ -5322,6 +5376,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5540,6 +5602,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
+      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-circular-progressbar": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.2.0.tgz",
@@ -5565,7 +5651,10 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+<<<<<<< Updated upstream
       "license": "MIT",
+=======
+>>>>>>> Stashed changes
       "peerDependencies": {
         "react": "*"
       }
@@ -6280,6 +6369,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/guardians/package.json
+++ b/guardians/package.json
@@ -15,6 +15,7 @@
     "latest": "^0.2.0",
     "pretendard": "^1.3.9",
     "react": "^19.0.0",
+    "react-calendar": "^5.1.0",
     "react-circular-progressbar": "^2.2.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/guardians/src/pages/Dashboard/DashboardPage.tsx
+++ b/guardians/src/pages/Dashboard/DashboardPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import axios from "axios";
 import SolvedLineChart from "./SolvedLineChart";
 import "react-circular-progressbar/dist/styles.css";
-import { motion } from "framer-motion";
 import RadarChart from "./RadarChart";
 
 interface Badge {

--- a/guardians/src/pages/Dashboard/RadarChart.tsx
+++ b/guardians/src/pages/Dashboard/RadarChart.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import {
+    Radar,
+    RadarChart,
+    PolarGrid,
+    PolarAngleAxis,
+    PolarRadiusAxis,
+    ResponsiveContainer,
+    Tooltip,
+} from "recharts";
+import axios from "axios";
+
+interface CategoryScore {
+    category: string;
+    normalizedScore: number;
+}
+
+interface RadarChartProps {
+    userId: number;
+    labelFontSize?: number; // ✅ 글자 크기 조절 가능
+}
+
+const RadarChartComponent = ({ userId, labelFontSize = 15 }: RadarChartProps) => {
+    const [data, setData] = useState<CategoryScore[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        axios
+            .get(`/api/users/${userId}/dashboard/radar`, { withCredentials: true })
+            .then((res) => {
+                setData(res.data.result.data);
+            })
+            .catch((err) => {
+                setError(true);
+                console.error("RadarChart 오류:", err);
+            })
+            .finally(() => setLoading(false));
+    }, [userId]);
+
+    if (loading) return <div>로딩 중...</div>;
+    if (error || data.length === 0) return <div>데이터 없음 😢</div>;
+
+    return (
+        <ResponsiveContainer width="100%" height="100%">
+            <RadarChart
+                cx="50%"
+                cy="58%" // ✅ 아래로 조금 내림
+                outerRadius="90%" // ✅ 기본값보다 살짝 줄여 위치 여유 확보
+                data={data}
+            >
+                <PolarGrid stroke="#ddd" strokeDasharray="3 2" />
+                <PolarAngleAxis
+                    dataKey="category"
+                    tick={{
+                        fontSize: labelFontSize, // ✅ 글자 크기 조절 가능
+                        fill: "#333",
+                    }}
+                    tickLine={false} // ✅ 라인 제거
+                    tickMargin={12} // ✅ 꼭짓점과 글자 사이 간격 확보
+                />
+                <PolarRadiusAxis
+                    domain={[0, 100]}
+                    tick={false}
+                    axisLine={false}
+                    stroke="#ccc"
+                />
+                <Tooltip
+                    contentStyle={{
+                        backgroundColor: "#fff8e1",
+                        border: "1px solid #ffc078",
+                        borderRadius: "8px",
+                        fontSize: "0.85rem",
+                        color: "#333",
+                    }}
+                    formatter={(value: number) => [`${value.toFixed(1)}점`, "정규화 점수"]}
+                />
+                <Radar
+                    name="정규화 점수"
+                    dataKey="normalizedScore"
+                    stroke="#ffa94d"
+                    fill="#ffa94d"
+                    fillOpacity={0.5}
+                    dot={{ r: 4 }}
+                />
+            </RadarChart>
+        </ResponsiveContainer>
+    );
+};
+
+export default RadarChartComponent;

--- a/guardians/src/pages/Dashboard/RadarChart.tsx
+++ b/guardians/src/pages/Dashboard/RadarChart.tsx
@@ -17,10 +17,9 @@ interface CategoryScore {
 
 interface RadarChartProps {
     userId: number;
-    labelFontSize?: number; // ✅ 글자 크기 조절 가능
 }
 
-const RadarChartComponent = ({ userId, labelFontSize = 15 }: RadarChartProps) => {
+const RadarChartComponent = ({ userId }: RadarChartProps) => {
     const [data, setData] = useState<CategoryScore[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
@@ -45,19 +44,19 @@ const RadarChartComponent = ({ userId, labelFontSize = 15 }: RadarChartProps) =>
         <ResponsiveContainer width="100%" height="100%">
             <RadarChart
                 cx="50%"
-                cy="58%" // ✅ 아래로 조금 내림
-                outerRadius="90%" // ✅ 기본값보다 살짝 줄여 위치 여유 확보
+                cy="58%" // 아래로 조금 내림
+                outerRadius="90%" // 기본보다 약간 축소
                 data={data}
             >
                 <PolarGrid stroke="#ddd" strokeDasharray="3 2" />
                 <PolarAngleAxis
                     dataKey="category"
                     tick={{
-                        fontSize: labelFontSize, // ✅ 글자 크기 조절 가능
-                        fill: "#333",
+                        fontSize: 13,
+                        fill: "#666",
+                        dy: 4, // 글자를 약간 아래로
                     }}
-                    tickLine={false} // ✅ 라인 제거
-                    tickMargin={12} // ✅ 꼭짓점과 글자 사이 간격 확보
+                    tickLine={false}
                 />
                 <PolarRadiusAxis
                     domain={[0, 100]}

--- a/guardians/src/pages/Dashboard/SolvedLineChart.tsx
+++ b/guardians/src/pages/Dashboard/SolvedLineChart.tsx
@@ -226,7 +226,7 @@ const SolvedLineChart = () => {
                                 setShowCalendar(false);
                             }}
                             value={selectedDate}
-                            formatDay={(locale, date) => String(date.getDate())}
+                            formatDay={(_, date) => String(date.getDate())}
                         />
                     </div>
                 )}

--- a/guardians/src/pages/Dashboard/SolvedLineChart.tsx
+++ b/guardians/src/pages/Dashboard/SolvedLineChart.tsx
@@ -1,8 +1,8 @@
-// dashboard/SolvedLineChart.tsx
-
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../context/AuthContext";
+import Calendar from "react-calendar";
 import axios from "axios";
+import "react-calendar/dist/Calendar.css";
 import {
     LineChart,
     Line,
@@ -12,6 +12,7 @@ import {
     Tooltip,
     ResponsiveContainer,
 } from "recharts";
+import { FaRegCalendarAlt } from "react-icons/fa";
 
 interface SolvedInfo {
     wargameId: number;
@@ -21,117 +22,245 @@ interface SolvedInfo {
     solvedAt: string;
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL;
-
-const parseLocalDate = (dateStr: string): Date => {
-    if (!dateStr || !dateStr.includes("T")) {
-        console.warn("Invalid date string:", dateStr);
-        return new Date();
-    }
-
-    const [datePart, timePart] = dateStr.split("T");
-    const [year, month, day] = datePart.split("-").map(Number);
-    const [hour, minute, second] = timePart.split(":").map(Number);
-    return new Date(year, month - 1, day, hour, minute, second);
+type DailySolvedCount = {
+    dayLabel: string;
+    count: number;
 };
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+const dayLabels = ["일", "월", "화", "수", "목", "금", "토"];
 
-const getWeekOfMonth = (date: Date) => {
-    const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
-    return Math.ceil((date.getDate() + firstDay.getDay()) / 7);
+const getWeekRange = (date: Date) => {
+    const day = date.getDay();
+    const monday = new Date(date);
+    monday.setDate(date.getDate() - ((day + 6) % 7));
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    return { start: monday, end: sunday };
+};
+
+const getDayLabel = (date: Date) => dayLabels[date.getDay()];
+
+const getISOWeekNumberInMonth = (date: Date): { year: number; month: number; week: number } => {
+    const monday = new Date(date);
+    monday.setDate(date.getDate() - ((monday.getDay() + 6) % 7));
+    const thursday = new Date(monday);
+    thursday.setDate(monday.getDate() + 3);
+    const targetMonth = thursday.getMonth();
+    const targetYear = thursday.getFullYear();
+
+    const firstOfMonth = new Date(targetYear, targetMonth, 1);
+    while (firstOfMonth.getDay() !== 4) {
+        firstOfMonth.setDate(firstOfMonth.getDate() + 1);
+    }
+    const firstWeekMonday = new Date(firstOfMonth);
+    firstWeekMonday.setDate(firstOfMonth.getDate() - 3);
+
+    const diff = monday.getTime() - firstWeekMonday.getTime();
+    const weekNumber = Math.floor(diff / (7 * 86400000)) + 1;
+
+    return {
+        year: targetYear,
+        month: targetMonth + 1,
+        week: weekNumber,
+    };
 };
 
 const SolvedLineChart = () => {
     const { user } = useAuth();
     const userId = user?.id;
-
-    const now = new Date();
-    const currentYear = now.getFullYear();
-
-    const [year, setYear] = useState(currentYear);
-    const [month, setMonth] = useState(5);
     const [solvedList, setSolvedList] = useState<SolvedInfo[]>([]);
+    const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+    const [showCalendar, setShowCalendar] = useState(false);
+    const [hoveredButton, setHoveredButton] = useState<"prev" | "next" | null>(null);
+    const calendarRef = useRef<HTMLDivElement>(null);
 
-    const handlePrevMonth = () => {
-        if (month === 1) {
-            setYear(prev => prev - 1);
-            setMonth(12);
-        } else {
-            setMonth(prev => prev - 1);
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (calendarRef.current && !calendarRef.current.contains(e.target as Node)) {
+                setShowCalendar(false);
+            }
+        };
+        if (showCalendar) {
+            document.addEventListener("mousedown", handleClickOutside);
         }
-    };
-
-    const handleNextMonth = () => {
-        const now = new Date();
-        const currentYear = now.getFullYear();
-        const currentMonth = now.getMonth() + 1;
-
-        if (year > currentYear || (year === currentYear && month >= currentMonth)) {
-            return; // ✅ 미래 달로 넘어가지 않도록 막기
-        }
-
-        if (month === 12) {
-            setYear(prev => prev + 1);
-            setMonth(1);
-        } else {
-            setMonth(prev => prev + 1);
-        }
-    };
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [showCalendar]);
 
     useEffect(() => {
         if (!userId) return;
         axios
             .get(`${API_BASE}/api/users/${userId}/solved`, { withCredentials: true })
             .then((res) => {
-                const list: SolvedInfo[] = res.data.result.data.solvedList;
-                console.log("📦 받아온 solvedList:", list.map((l) => l.solvedAt));
-                setSolvedList(list);
+                setSolvedList(res.data.result.data.solvedList);
             })
             .catch((err) => {
                 console.error("문제 목록 불러오기 실패:", err);
             });
     }, [userId]);
 
-    const weeklyData = useMemo(() => {
-        const counts = [0, 0, 0, 0, 0];
+    const weeklyData: DailySolvedCount[] = useMemo(() => {
+        const { start } = getWeekRange(selectedDate);
+        const dailyCountMap: Record<string, number> = {};
+        for (let i = 0; i < 7; i++) {
+            const date = new Date(start);
+            date.setDate(start.getDate() + i);
+            dailyCountMap[getDayLabel(date)] = 0;
+        }
+
         solvedList.forEach((item) => {
-            const date = parseLocalDate(item.solvedAt); // ✅ 변경
-            if (date.getFullYear() !== year || date.getMonth() + 1 !== month) return;
-            const week = getWeekOfMonth(date);
-            if (week >= 1 && week <= 5) counts[week - 1]++;
+            const date = new Date(item.solvedAt);
+            const { start, end } = getWeekRange(selectedDate);
+            if (date >= start && date <= end) {
+                const label = getDayLabel(date);
+                if (label in dailyCountMap) {
+                    dailyCountMap[label]++;
+                }
+            }
         });
-        return counts.map((count, i) => ({
-            week: `${i + 1}주차`,
+
+        return Object.entries(dailyCountMap).map(([dayLabel, count]) => ({
+            dayLabel,
             count,
         }));
-    }, [solvedList, year, month]);
+    }, [solvedList, selectedDate]);
 
-    const label = `${year !== currentYear ? `${year}년 ` : ""}${month}월에 푼 문제 수`;
+    const handlePrevWeek = () => {
+        const newDate = new Date(selectedDate);
+        newDate.setDate(newDate.getDate() - 7);
+        setSelectedDate(newDate);
+    };
+
+    const handleNextWeek = () => {
+        const now = new Date();
+        const nextDate = new Date(selectedDate);
+        nextDate.setDate(selectedDate.getDate() + 7);
+        if (nextDate > now) return;
+        setSelectedDate(nextDate);
+    };
+
+    const { month, year, week } = getISOWeekNumberInMonth(selectedDate);
+    const weekTitle = `${year !== new Date().getFullYear() ? `${year}년 ` : ""}${month}월 ${week}주차`;
+
+    // ❗ 버튼 스타일: 얇고 작게, 밑줄만 있는 심플한 형태
+    const arrowButtonStyle = (type: "prev" | "next"): React.CSSProperties => ({
+        background: "none",
+        border: "none",
+        borderBottom: `1px solid ${hoveredButton === type ? "#ffa94d" : "#ccc"}`,
+        fontSize: "1rem", // 작게 줄임
+        color: hoveredButton === type ? "#ffa94d" : "#333",
+        cursor: "pointer",
+        padding: "0.5rem 0.8rem",
+        lineHeight: 1,
+        transition: "all 0.2s",
+        outline: "none", // ✅ 포커스 시 까만 테두리 제거
+    });
 
     return (
-        <div style={{ width: "100%", height: "100%" }}>
-            <div style={{ textAlign: "center", marginBottom: "1rem" }}>
-                <button onClick={handlePrevMonth}>〈</button>
-                <span style={{ margin: "0 1rem", fontWeight: "bold" }}>{label}</span>
-                <button onClick={handleNextMonth}>〉</button>
+        <div style={{ width: "100%", height: "100%", position: "relative" }}>
+            {/* 상단 네비게이션 영역 */}
+            <div
+                style={{
+                    textAlign: "center",
+                    marginBottom: "1rem",
+                    position: "relative",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    gap: "1rem",
+                }}
+            >
+                <button
+                    onClick={handlePrevWeek}
+                    style={arrowButtonStyle("prev")}
+                    onMouseEnter={() => setHoveredButton("prev")}
+                    onMouseLeave={() => setHoveredButton(null)}
+                >
+                    ❮
+                </button>
+
+                <span
+                    style={{
+                        fontWeight: 400,
+                        fontSize: "1rem",
+                        color: "#666",
+                        cursor: "pointer",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "0.5rem",
+                    }}
+                    onClick={() => setShowCalendar((prev) => !prev)}
+                >
+                    {weekTitle}
+                    <FaRegCalendarAlt size={16} />
+                </span>
+
+                <button
+                    onClick={handleNextWeek}
+                    style={arrowButtonStyle("next")}
+                    onMouseEnter={() => setHoveredButton("next")}
+                    onMouseLeave={() => setHoveredButton(null)}
+                >
+                    ❯
+                </button>
+
+                {showCalendar && (
+                    <div
+                        ref={calendarRef}
+                        style={{
+                            position: "absolute",
+                            top: "2.5rem",
+                            left: "50%",
+                            transform: "translateX(-50%)",
+                            zIndex: 999,
+                            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                            backgroundColor: "#fff",
+                        }}
+                    >
+                        <Calendar
+                            locale="ko-KR"
+                            onChange={(date) => {
+                                setSelectedDate(date as Date);
+                                setShowCalendar(false);
+                            }}
+                            value={selectedDate}
+                            formatDay={(locale, date) => String(date.getDate())}
+                        />
+                    </div>
+                )}
             </div>
 
-            <ResponsiveContainer width="100%" height="85%">
-                <LineChart data={weeklyData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="week" />
-                    <YAxis allowDecimals={false} domain={[0, Math.max(...weeklyData.map(d => d.count), 5)]} />
-                    <Tooltip />
-                    <Line
-                        type="monotone"
-                        dataKey="count"
-                        stroke="#28a745"
-                        strokeWidth={2}
-                        dot={{ r: 4, fill: "#fff", stroke: "#000", strokeWidth: 2 }}
-                        activeDot={{ r: 6 }}
-                    />
-                </LineChart>
-            </ResponsiveContainer>
+            {/* 그래프 */}
+            <div
+                style={{
+                    height: "85%",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                }}
+            >
+                <ResponsiveContainer width="100%" height="100%">
+                    <LineChart
+                        data={weeklyData}
+                        margin={{ top: 10, right: 10, left: -20, bottom: 10 }}
+                    >
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="dayLabel" tickMargin={10} />
+                        <YAxis allowDecimals={false} tickMargin={10} />
+                        <Tooltip />
+                        <Line
+                            type="monotone"
+                            dataKey="count"
+                            stroke="#007bff"
+                            strokeWidth={2}
+                            dot={{ r: 4, fill: "#fff", stroke: "#007bff", strokeWidth: 2 }}
+                            activeDot={{ r: 6 }}
+                        />
+                    </LineChart>
+                </ResponsiveContainer>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## 📌 PR 제목
- feat: 대시보드 페이지 구현 및 정규화 점수 시각화 추가

---

## ✨ 주요 변경사항
### **npm install react-calendar react-icons**

- 사용자 정보, 랭킹, 점수, 문제 수를 시각화하는 대시보드 페이지 추가
- RadarChart를 통한 종합 역량 진단표 시각화 구현
- LineChart를 이용한 주간 문제 풀이 수 시계열 그래프 구현
- 사용자 뱃지 목록 및 설명 툴팁 UI 구성
- 티어 설명 및 뱃지 설명 버튼/모달 구현
- 날짜 선택 가능한 주차별 캘린더 내장
- API 연동을 통한 실시간 사용자 정보, 통계 데이터, 뱃지 목록 로딩 처리

---

## 🔍 상세 설명
- 사용자 대시보드 페이지는 유저의 활동 데이터를 한 눈에 확인할 수 있도록 구성됨
- 좌측에는 사용자 프로필 및 티어, 랭킹/점수/문제수 현황 카드로 구성
- 우측에는 획득한 뱃지를 나열하고, 버튼을 통해 상세 설명 확인 가능
- 하단에는 주간 기준으로 문제 풀이 수를 보여주는 라인 차트와, 카테고리별 정규화 점수를 나타내는 레이더 차트를 배치함
- 사용자 경험을 높이기 위해 `react-calendar`, `recharts`, `framer-motion` 등을 활용해 인터랙티브한 UI로 구성
- 실시간 API 데이터를 기반으로 로딩/오류 처리도 포함

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Swagger로 API 응답 확인
- [x] 프론트에서 RadarChart, SolvedLineChart 연동 테스트 완료
- [ ] (선택) 유닛/통합 테스트는 포함되지 않음

---

## 📎 관련 이슈


---

## 💬 기타 공유사항
- 차트의 높이, 위치는 화면 반응형 기준에 맞춰 설정되어 있음
- 향후 사용자별 트렌드 분석을 위한 추가 그래프 고려 가능
- 뱃지 조건이 DB에 반영된 상태에서만 실제 뱃지 획득 여부가 정확히 표시됨