### PR TITLE
feat : add AdminPages for user control and job listing management

### DIFF
--- a/guardians/src/App.tsx
+++ b/guardians/src/App.tsx
@@ -34,11 +34,20 @@ import QnaDetailPage from "./pages/Community/QnaDetailPage.tsx";
 import QnaWrite from "./pages/Community/QnaWrite.tsx";
 import BoardEdit from "./pages/Community/BoardEdit.tsx";
 
+import AdminLoginPage from "./pages/AdminPage/AdminLoginPage.tsx";
+import AdminWargameListPage from "./pages/AdminPage/WargamePage/WargameListPage.tsx";
+import JobListPage from "./pages/AdminPage/JobPage/JobListPage";
+import UserManagementPage from "./pages/AdminPage/UserPage/UserManagementPage";
+
 function App() {
     const location = useLocation();
 
     const authPaths = ["/login", "/signup", "/signup/success", "/findPassword"];
-    const isAuthPage = authPaths.includes(location.pathname);
+    // 🔽 여기에 추가
+    const isAdminPage = location.pathname.startsWith("/admin");
+    const isAuthPage = authPaths.includes(location.pathname) || isAdminPage;
+
+
 
     return (
         <AuthProvider>
@@ -132,6 +141,11 @@ function App() {
                     <Route path="/community/inquiry/:id" element={<InquiryBoardDetailPage />} />
                     <Route path="/community/inquiry/edit/:id" element={<BoardEdit />} />
                     <Route path="/job/:id" element={<JobDetailPage />} />
+
+                    <Route path="/admin/login" element={<AdminLoginPage />} />
+                    <Route path="/admin/wargames" element={<AdminWargameListPage />} />
+                    <Route path="/admin/jobs" element={<JobListPage />} />
+                    <Route path="/admin/users" element={<UserManagementPage />} />
 
                 </Routes>
                 {!isAuthPage && <Footer />}

--- a/guardians/src/pages/AdminPage/AdminLoginPage.tsx
+++ b/guardians/src/pages/AdminPage/AdminLoginPage.tsx
@@ -1,0 +1,99 @@
+// src/pages/AdminPage/AdminLoginPage.tsx
+
+import { useState } from "react";
+import axios from "axios";
+import styles from "../LoginPage/Login.module.css"; // ✅ 로그인과 동일한 스타일 사용
+import emailIcon from "../../assets/mail.png";
+import lockIcon from "../../assets/lock.png";
+import ErrorModal from "../ErrorModal/ErrorModal";
+
+const AdminLoginPage = () => {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [errorMsg, setErrorMsg] = useState("");
+    const [showModal, setShowModal] = useState(false);
+
+    const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+    const handleLogin = async () => {
+        if (!email.trim() || !password.trim()) {
+            setErrorMsg("이메일과 비밀번호를 모두 입력해주세요.");
+            setShowModal(true);
+            return;
+        }
+
+        try {
+            await axios.post(
+                `${API_BASE}/api/users/admin/login`, // ✅ 관리자 로그인 API
+                { email, password },
+                { withCredentials: true }
+            );
+            // 로그인 성공 후 이동
+            window.location.href = "/admin/wargames";
+        } catch (err: unknown) {
+            if (axios.isAxiosError(err)) {
+                setErrorMsg(err.response?.data?.message || "관리자 로그인 실패");
+            } else {
+                setErrorMsg("알 수 없는 오류가 발생했습니다.");
+            }
+            setShowModal(true);
+        }
+    };
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        handleLogin();
+    };
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.left}>
+                <div className={styles.textBox} style={{ marginTop: "3rem" }}>
+                    <p>환영합니다,</p>
+                    <p>
+                        <span style={{ fontWeight: "750", color: "#fff" }}>가디언즈</span>{" "}
+                        <strong style={{ fontSize: "2.1rem", color: "white" }}>운영자 전용 페이지</strong>입니다.
+                    </p>
+                </div>
+                <img src="/login_logo.png" alt="login visual" className={styles.visual} />
+            </div>
+
+            <div className={styles.right}>
+                <form className={styles.loginBox} onSubmit={handleSubmit} autoComplete="on">
+                    <h2 className={styles.title}>관리자 로그인</h2>
+                    <div className={styles.inputSection}>
+                        <div className={styles.inputGroup}>
+                            <img src={emailIcon} alt="email" />
+                            <input
+                                type="email"
+                                placeholder="관리자 이메일"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className={styles.inputGroup}>
+                            <img src={lockIcon} alt="lock" />
+                            <input
+                                type="password"
+                                placeholder="비밀번호"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                required
+                            />
+                        </div>
+                    </div>
+                    <div className={styles.buttonSection}>
+                        <button type="submit" className={styles.loginButton}>
+                            로그인하기
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            {showModal && <ErrorModal message={errorMsg} onClose={() => setShowModal(false)} />}
+        </div>
+    );
+};
+
+export default AdminLoginPage;

--- a/guardians/src/pages/AdminPage/AdminSidebar.tsx
+++ b/guardians/src/pages/AdminPage/AdminSidebar.tsx
@@ -1,0 +1,58 @@
+// src/pages/AdminPage/AdminSidebar.tsx
+
+import { Link, useLocation } from "react-router-dom";
+
+const AdminSidebar = () => {
+    const location = useLocation();
+
+    const menuItems = [
+        { path: "/admin/wargames", label: "워게임 관리" },
+        { path: "/admin/jobs", label: "커리어 관리" },
+        { path: "/admin/users", label: "회원 관리" },
+    ];
+
+    return (
+        <aside
+            style={{
+                width: "180px",
+                padding: "0.5rem 1rem",
+                borderRight: "1px solid #ddd",
+                backgroundColor: "#fff",
+                borderRadius: "10px",
+                boxShadow: "0 0 4px rgba(0,0,0,0.06)",
+                height: "fit-content",
+            }}
+        >
+            <h3 style={{ fontSize: "1.1rem", marginBottom: "1.5rem", fontWeight: 700, color: "#444" }}>
+                🛠️ 관리자 메뉴
+            </h3>
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {menuItems.map((item) => {
+                    const isActive = location.pathname === item.path;
+
+                    return (
+                        <li key={item.path} style={{ marginBottom: "1rem" }}>
+                            <Link
+                                to={item.path}
+                                style={{
+                                    display: "block",
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "6px",
+                                    textDecoration: "none",
+                                    fontWeight: isActive ? 700 : 500,
+                                    color: isActive ? "#fff" : "#333",
+                                    backgroundColor: isActive ? "#FFA94D" : "transparent",
+                                    transition: "all 0.2s ease-in-out",
+                                }}
+                            >
+                                {item.label}
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </aside>
+    );
+};
+
+export default AdminSidebar;

--- a/guardians/src/pages/AdminPage/JobPage/JobListPage.tsx
+++ b/guardians/src/pages/AdminPage/JobPage/JobListPage.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import AdminSidebar from "../AdminSidebar"; // 경로 맞음
+
+export interface ResJobDto {
+    jobId: number;
+    title: string;
+    companyName: string;
+    location: string;
+    employmentType: string;
+    deadline: string;
+    careerLevel: string;
+    sourceUrl: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+const JobListPage = () => {
+    const [jobs, setJobs] = useState<ResJobDto[]>([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 10;
+
+    const fetchJobs = async () => {
+        try {
+            const res = await axios.get(`${API_BASE}/api/jobs`, {
+                withCredentials: true,
+            });
+            setJobs(res.data.result.data);
+        } catch (err) {
+            console.error("채용공고 목록 불러오기 실패:", err);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+
+        try {
+            await axios.delete(`${API_BASE}/api/jobs/${id}`, {
+                withCredentials: true,
+            });
+            setJobs(prev => prev.filter(job => job.jobId !== id));
+            alert("삭제 완료되었습니다.");
+        } catch (err) {
+            console.error("채용공고 삭제 실패:", err);
+            alert("삭제에 실패했습니다.");
+        }
+    };
+
+    useEffect(() => {
+        fetchJobs();
+    }, []);
+
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const currentItems = jobs.slice(startIndex, startIndex + itemsPerPage);
+    const totalPages = Math.ceil(jobs.length / itemsPerPage);
+
+    return (
+        <div style={{ paddingTop: "120px", paddingLeft: "2rem", paddingRight: "2rem" }}>
+            <div style={{ maxWidth: "1200px", margin: "0 auto", display: "flex", gap: "2rem", alignItems: "flex-start" }}>
+                <AdminSidebar />
+
+                <div style={{ flex: 1 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
+                        <h2 style={{ fontSize: "1.5rem", fontWeight: 700 }}>📄 커리어 관리</h2>
+                        <button
+                            style={{
+                                padding: "0.5rem 1rem",
+                                backgroundColor: "#ffa94d",
+                                border: "none",
+                                borderRadius: "6px",
+                                cursor: "pointer",
+                                color: "#fff",
+                                fontWeight: 600,
+                            }}
+                            onClick={() => alert("등록 페이지로 이동 (추후 구현)")}
+                        >
+                            + 채용공고 생성
+                        </button>
+                    </div>
+
+                    <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+                        <colgroup>
+                            <col style={{ width: "10%" }} />
+                            <col style={{ width: "30%" }} />
+                            <col style={{ width: "40%" }} />
+                            <col style={{ width: "20%" }} />
+                        </colgroup>
+                        <thead>
+                        <tr style={{ backgroundColor: "#f0f0f0" }}>
+                            <th style={thStyle}>#</th>
+                            <th style={thStyle}>회사명</th>
+                            <th style={thStyle}>공고 제목</th>
+                            <th style={thStyle}>관리</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currentItems.map((job, idx) => (
+                            <tr key={job.jobId}>
+                                <td style={tdStyle}>{startIndex + idx + 1}</td>
+                                <td style={tdStyle}>{job.companyName}</td>
+                                <td style={tdStyle}>{job.title}</td>
+                                <td style={tdStyle}>
+                                    <button
+                                        onClick={() => handleDelete(job.jobId)}
+                                        style={{
+                                            backgroundColor: "#ff6b6b",
+                                            color: "#fff",
+                                            border: "none",
+                                            borderRadius: "4px",
+                                            padding: "0.3rem 0.6rem",
+                                            cursor: "pointer",
+                                        }}
+                                    >
+                                        삭제
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i + 1}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#ffa94d" : "#f5f5f5",
+                                    border: "1px solid #ccc",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                    fontWeight: 600,
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const thStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    fontWeight: "bold",
+    borderBottom: "1px solid #ccc",
+    whiteSpace: "nowrap",
+};
+
+const tdStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    borderBottom: "1px solid #eee",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+};
+
+export default JobListPage;

--- a/guardians/src/pages/AdminPage/UserPage/UserManagementPage.tsx
+++ b/guardians/src/pages/AdminPage/UserPage/UserManagementPage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import AdminSidebar from "../AdminSidebar";
+
+interface User {
+    id: number;
+    username: string;
+    email: string;
+    role: string;
+    lastLoginAt: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+const ITEMS_PER_PAGE = 5;
+
+const UserManagementPage = () => {
+    const [users, setUsers] = useState<User[]>([]);
+    const [adminPage, setAdminPage] = useState(1);
+    const [userPage, setUserPage] = useState(1);
+
+    const fetchUsers = async () => {
+        try {
+            const res = await axios.get(`${API_BASE}/api/users/admin/list`, {
+                withCredentials: true,
+            });
+            setUsers(res.data.result.data);
+        } catch (err) {
+            console.error("회원 목록 불러오기 실패:", err);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+        try {
+            await axios.delete(`${API_BASE}/api/users/admin/delete/${id}`, {
+                withCredentials: true,
+            });
+            setUsers(prev => prev.filter(user => user.id !== id));
+            alert("삭제 완료되었습니다.");
+        } catch (err) {
+            console.error("회원 삭제 실패:", err);
+            alert("삭제에 실패했습니다.");
+        }
+    };
+
+    useEffect(() => {
+        fetchUsers();
+    }, []);
+
+    const formatDateTime = (raw: string) => {
+        if (!raw || raw.length !== 14) return "-";
+        return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)} ${raw.slice(8, 10)}:${raw.slice(10, 12)}`;
+    };
+
+    const adminList = users.filter(u => u.role === "ADMIN");
+    const userList = users.filter(u => u.role === "USER");
+
+    const adminTotalPages = Math.ceil(adminList.length / ITEMS_PER_PAGE);
+    const userTotalPages = Math.ceil(userList.length / ITEMS_PER_PAGE);
+
+    const adminCurrent = adminList.slice((adminPage - 1) * ITEMS_PER_PAGE, adminPage * ITEMS_PER_PAGE);
+    const userCurrent = userList.slice((userPage - 1) * ITEMS_PER_PAGE, userPage * ITEMS_PER_PAGE);
+
+    return (
+        <div style={{ paddingTop: "120px", paddingLeft: "2rem", paddingRight: "2rem" }}>
+            <div style={{ maxWidth: "1200px", margin: "0 auto", display: "flex", gap: "2rem", alignItems: "flex-start" }}>
+                <AdminSidebar />
+
+                <div style={{ flex: 1 }}>
+                    <h2 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "2rem" }}>👤 회원 관리</h2>
+
+                    <h3 style={{ marginBottom: "0.5rem", fontWeight: 400 }}>• 관리자 ({adminList.length}명)</h3>
+                    <UserTable users={adminCurrent} handleDelete={handleDelete} formatDateTime={formatDateTime} />
+                    <Pagination page={adminPage} setPage={setAdminPage} totalPages={adminTotalPages} />
+
+                    <h3 style={{ marginTop: "2rem", marginBottom: "0.5rem", fontWeight: 400 }}>• 일반 사용자 ({userList.length}명)</h3>
+                    <UserTable users={userCurrent} handleDelete={handleDelete} formatDateTime={formatDateTime} />
+                    <Pagination page={userPage} setPage={setUserPage} totalPages={userTotalPages} />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const UserTable = ({
+                       users,
+                       handleDelete,
+                       formatDateTime,
+                   }: {
+    users: User[];
+    handleDelete: (id: number) => void;
+    formatDateTime: (raw: string) => string;
+}) => (
+    <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed", marginBottom: "1rem" }}>
+        <colgroup>
+            <col style={{ width: "5%" }} />
+            <col style={{ width: "20%" }} />
+            <col style={{ width: "30%" }} />
+            <col style={{ width: "25%" }} />
+            <col style={{ width: "20%" }} />
+        </colgroup>
+        <thead>
+        <tr style={{ backgroundColor: "#f0f0f0" }}>
+            <th style={thStyle}>#</th>
+            <th style={thStyle}>이름</th>
+            <th style={thStyle}>이메일</th>
+            <th style={thStyle}>마지막 로그인</th>
+            <th style={thStyle}>관리</th>
+        </tr>
+        </thead>
+        <tbody>
+        {users.map((user, idx) => (
+            <tr key={user.id}>
+                <td style={tdStyle}>{idx + 1}</td>
+                <td style={tdStyle}>{user.username}</td>
+                <td style={tdStyle}>{user.email}</td>
+                <td style={tdStyle}>{formatDateTime(user.lastLoginAt)}</td>
+                <td style={tdStyle}>
+                    <button
+                        onClick={() => handleDelete(user.id)}
+                        style={{
+                            backgroundColor: "#ff6b6b",
+                            color: "#fff",
+                            border: "none",
+                            borderRadius: "4px",
+                            padding: "0.3rem 0.6rem",
+                            cursor: "pointer",
+                        }}
+                    >
+                        삭제
+                    </button>
+                </td>
+            </tr>
+        ))}
+        </tbody>
+    </table>
+);
+
+const Pagination = ({
+                        page,
+                        setPage,
+                        totalPages,
+                    }: {
+    page: number;
+    setPage: (page: number) => void;
+    totalPages: number;
+}) => (
+    <div style={{ marginBottom: "2rem", textAlign: "center", minHeight: "2.5rem" }}>
+        {Array.from({ length: totalPages }, (_, i) => (
+            <button
+                key={i}
+                onClick={() => setPage(i + 1)}
+                style={{
+                    margin: "0 0.25rem",
+                    padding: "0.4rem 0.75rem",
+                    backgroundColor: page === i + 1 ? "#ffa94d" : "#f5f5f5",
+                    border: "1px solid #ccc",
+                    borderRadius: "4px",
+                    cursor: "pointer",
+                    fontWeight: 600,
+                }}
+            >
+                {i + 1}
+            </button>
+        ))}
+    </div>
+);
+
+const thStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    fontWeight: "bold",
+    borderBottom: "1px solid #ccc",
+    whiteSpace: "nowrap",
+};
+
+const tdStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    borderBottom: "1px solid #eee",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+};
+
+export default UserManagementPage;

--- a/guardians/src/pages/AdminPage/WargamePage/WargameListPage.tsx
+++ b/guardians/src/pages/AdminPage/WargamePage/WargameListPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import AdminSidebar from "../AdminSidebar"; // 경로 주의
+
+interface Wargame {
+    id: number;
+    title: string;
+    categoryName: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+const AdminWargameListPage = () => {
+    const [wargames, setWargames] = useState<Wargame[]>([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 10;
+
+    const fetchWargames = async () => {
+        try {
+            const res = await axios.get(`${API_BASE}/api/wargames`, {
+                withCredentials: true,
+            });
+            setWargames(res.data.result.data);
+        } catch (err) {
+            console.error("워게임 목록 불러오기 실패:", err);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+
+        try {
+            await axios.delete(`${API_BASE}/api/wargames/admin/${id}`, {
+                withCredentials: true,
+            });
+            setWargames(prev => prev.filter(w => w.id !== id));
+            alert("삭제 완료되었습니다.");
+        } catch (err) {
+            console.error("워게임 삭제 실패:", err);
+            alert("삭제에 실패했습니다.");
+        }
+    };
+
+    useEffect(() => {
+        fetchWargames();
+    }, []);
+
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const currentItems = wargames.slice(startIndex, startIndex + itemsPerPage);
+    const totalPages = Math.ceil(wargames.length / itemsPerPage);
+
+    return (
+        <div style={{ paddingTop: "120px", paddingLeft: "2rem", paddingRight: "2rem" }}>
+            <div style={{
+                maxWidth: "1200px",
+                margin: "0 auto",
+                display: "flex",
+                gap: "2rem",
+                alignItems: "flex-start"
+            }}>
+                <AdminSidebar />
+
+                <div style={{ flex: 1 }}>
+                    <div style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "1rem"
+                    }}>
+                        <h2 style={{ fontSize: "1.5rem", fontWeight: 700 }}>🔐 워게임 관리</h2>
+                        <button
+                            style={{
+                                padding: "0.5rem 1rem",
+                                backgroundColor: "#ffa94d",
+                                border: "none",
+                                borderRadius: "6px",
+                                cursor: "pointer",
+                                color: "#fff",
+                                fontWeight: 600,
+                            }}
+                            onClick={() => alert("등록 페이지로 이동 (추후 구현)")}
+                        >
+                            + 워게임 생성
+                        </button>
+                    </div>
+
+                    <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+                        <colgroup>
+                            <col style={{ width: "8%" }} />
+                            <col style={{ width: "22%" }} />
+                            <col style={{ width: "50%" }} />
+                            <col style={{ width: "20%" }} />
+                        </colgroup>
+                        <thead>
+                        <tr style={{ backgroundColor: "#f0f0f0" }}>
+                            <th style={thStyle}>#</th>
+                            <th style={thStyle}>카테고리</th>
+                            <th style={thStyle}>워게임명</th>
+                            <th style={thStyle}>관리</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currentItems.map((w, idx) => (
+                            <tr key={w.id}>
+                                <td style={tdStyle}>{startIndex + idx + 1}</td>
+                                <td style={tdStyle}>{w.categoryName}</td>
+                                <td style={tdStyle}>{w.title}</td>
+                                <td style={tdStyle}>
+                                    <button
+                                        onClick={() => handleDelete(w.id)}
+                                        style={{
+                                            backgroundColor: "#ff6b6b",
+                                            color: "#fff",
+                                            border: "none",
+                                            borderRadius: "4px",
+                                            padding: "0.3rem 0.6rem",
+                                            cursor: "pointer",
+                                        }}
+                                    >
+                                        삭제
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+
+                    <div style={{ marginTop: "1.5rem", textAlign: "center" }}>
+                        {Array.from({ length: totalPages }, (_, i) => (
+                            <button
+                                key={i + 1}
+                                onClick={() => setCurrentPage(i + 1)}
+                                style={{
+                                    margin: "0 0.25rem",
+                                    padding: "0.4rem 0.75rem",
+                                    backgroundColor: currentPage === i + 1 ? "#ffa94d" : "#f5f5f5",
+                                    border: "1px solid #ccc",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                    fontWeight: 600,
+                                }}
+                            >
+                                {i + 1}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const thStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    fontWeight: "bold",
+    borderBottom: "1px solid #ccc",
+    whiteSpace: "nowrap",
+};
+
+const tdStyle = {
+    padding: "0.75rem",
+    textAlign: "left" as const,
+    borderBottom: "1px solid #eee",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+};
+
+export default AdminWargameListPage;


### PR DESCRIPTION
## 📌 PR 제목
feat : 관리자 전용 페이지 생성 (워게임 /커리어 /회원 관리 기능)

---

## ✨ 주요 변경사항
- 관리자 전용 페이지(/admin)에서 사용자 관리 및 채용공고 관리 기능 구현

- 워게임 목록 관리, 채용공고 관리, 회원 목록 확인 및 삭제 기능 추가

---

## 🔍 상세 설명
1. /admin/users : 사용자 목록을 일반 사용자/관리자로 구분하여 표출 및 삭제 기능 제공

2. /admin/jobs : 채용공고 목록 조회 및 삭제 기능 추가

3. /admin/wargames : 워게임 목록 확인 및 삭제 기능 제공

**App.tsx 주의사항**
```
admin 경로로 시작하는 페이지는 헤더를 components/AuthHeader.tsx로 임시 설정

const authPaths = ["/login", "/signup", "/signup/success", "/findPassword"];
const isAdminPage = location.pathname.startsWith("/admin");
const isAuthPage = authPaths.includes(location.pathname) || isAdminPage;
```
---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [ ] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [ ] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 API 테스트
- [x] 프론트에서 연동 확인
- [ ] 유닛/통합 테스트 포함 (있다면)

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 등록 기능은 버튼만 생성되어 있고 후속 작업 예정
