### PR TITLE
feat: Add confirmation modal for board and QnA edit actions

### DIFF
--- a/guardians/src/App.tsx
+++ b/guardians/src/App.tsx
@@ -44,6 +44,7 @@ import JobListPage from "./pages/AdminPage/JobPage/JobListPage";
 import UserManagementPage from "./pages/AdminPage/UserPage/UserManagementPage";
 import WargameCreatePage from "./pages/AdminPage/WargamePage/WargameCreatePage.tsx";
 import JobCreatePage from "./pages/AdminPage/JobPage/JobCreatePage.tsx";
+import QnaEdit from "./pages/Community/QnaEdit.tsx";
 
 function App() {
     const location = useLocation();
@@ -152,6 +153,7 @@ function App() {
                     <Route path="/community/qna" element={<QnaBoardPage />} />
                     <Route path="/community/qna/write" element={<QnaWrite />} />
                     <Route path="/community/qna/:id" element={<QnaDetailPage />} />
+                    <Route path="/community/qna/edit/:id" element={<QnaEdit />} />
                     <Route path="/community/study" element={<StudyBoardPage />} />
                     <Route path="/community/study/write" element={<BoardWrite type="STUDY" />} />
                     <Route path="/community/study/:id" element={<StudyBoardDetailPage />} />

--- a/guardians/src/pages/Community/BoardEdit.tsx
+++ b/guardians/src/pages/Community/BoardEdit.tsx
@@ -2,13 +2,20 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import styles from "./BoardWrite.module.css";
+import Modal from "./components/Modal.tsx";
 
 const BoardEdit = () => {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
-    const [type, setType] = useState<string>('');
+    const [type, setType] = useState<string>('')
+
+    const [showModal, setShowModal] = useState(false);
+    const [modalMessage, setModalMessage] = useState('');
+    const [modalOnConfirm, setModalOnConfirm] = useState<() => void>(() => {});
+    const [showCancelButton, setShowCancelButton] = useState(false);
+
 
     useEffect(() => {
         if (!id) return;
@@ -35,6 +42,19 @@ const BoardEdit = () => {
             });
     };
 
+    const handleSubmitClick = () => {
+        if (!title || !content) {
+            setModalMessage("제목과 내용을 모두 입력해주세요.");
+            setModalOnConfirm(() => () => setShowModal(false));  // 확인 시 모달 닫기
+            setShowCancelButton(false);  // 확인 버튼만
+        } else {
+            setModalMessage("정말 수정하시겠습니까?");
+            setModalOnConfirm(() => handleSubmit);  // 확인 시 handleSubmit 호출
+            setShowCancelButton(true);  // 확인/취소 버튼
+        }
+        setShowModal(true);  // 모달 열기
+    };
+
     const handleCancel = () => {
         navigate(`/community/${type}`);
     };
@@ -56,9 +76,19 @@ const BoardEdit = () => {
                 className={styles.textarea}
             />
             <div className={styles.btnGroup}>
-                <button onClick={handleSubmit} className={styles.submitBtn}>수정</button>
+                <button onClick={handleSubmitClick} className={styles.submitBtn}>수정</button>
                 <button onClick={handleCancel} className={styles.cancelBtn}>취소</button>
             </div>
+            <Modal
+                isOpen={showModal}
+                onClose={() => setShowModal(false)}
+                onConfirm={() => {
+                    modalOnConfirm();
+                    setShowModal(false);
+                }}
+                message={modalMessage}
+                showCancelButton={showCancelButton}
+            />
         </div>
     );
 };

--- a/guardians/src/pages/Community/QnaEdit.tsx
+++ b/guardians/src/pages/Community/QnaEdit.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import {useNavigate, useParams} from "react-router-dom";
+import axios from "axios";
+import styles from "./BoardWrite.module.css";
+import Modal from "../Community/components/Modal.tsx";
+
+type Wargame = {
+    id: number;
+    title: string;
+};
+
+type Question = {
+    id: number;
+    title: string;
+    content: string;
+    wargameId: number;
+    wargameTitle: string;
+};
+
+const QnaEdit = () => {
+    const { id } = useParams<{ id: string }>();
+    const [title, setTitle] = useState('');
+    const [content, setContent] = useState('');
+    const [selected, setSelected] = useState<Wargame | null>(null);
+
+    const navigate = useNavigate();
+
+    const [modalMessage, setModalMessage] = useState('');
+    const [showModal, setShowModal] = useState(false);
+    const [modalOnConfirm, setModalOnConfirm] = useState<() => void>(() => {});
+    const [showCancelButton, setShowCancelButton] = useState(false);
+
+
+    useEffect(() => {
+        axios.get(`/api/qna/questions/${id}`)
+            .then(res => {
+                const data: Question = res.data.result.data;
+                setTitle(data.title);
+                setContent(data.content);
+                setSelected({ id: data.wargameId, title: data.wargameTitle });
+            })
+            .catch(err => {
+                console.error("질문 상세 불러오기 실패", err);
+            });
+    }, [id, navigate]);
+
+    const handleSubmitClick = () => {
+        if (!title || !content || !selected) {
+            setModalMessage("제목, 내용, 워게임을 모두 입력해주세요.");
+            setModalOnConfirm(() => () => setShowModal(false));
+            setShowCancelButton(false);
+            setShowModal(true);
+            return;
+        }
+
+        setModalMessage("질문을 수정하시겠습니까?");
+        setModalOnConfirm(() => handleSubmit);
+        setShowCancelButton(true);
+        setShowModal(true);
+    };
+
+    const handleSubmit = async () => {
+        try {
+            await axios.patch(`/api/qna/questions/${id}`, {
+                title,
+                content,
+                wargameId: selected!.id
+            }, { withCredentials: true });
+           navigate("/community/qna");
+        } catch (err) {
+            console.error('질문 수정 실패', err);
+        }
+    };
+
+    const handleCancel = () => {
+        navigate("/community/qna");
+    };
+
+    return (
+        <div className={styles.wrapper} style={{ position: "relative" }}>
+            <h2 className={styles.pageTitle}>질문 수정</h2>
+
+
+            {selected && (
+                <div style={{ marginTop: "-1rem", marginBottom: "1rem", fontSize: "1rem", color: "#666" }}>
+                    선택된 워게임: <strong>{selected.title}</strong>
+                </div>
+            )}
+
+            <input
+                type="text"
+                placeholder="제목을 입력하세요"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className={styles.input}
+            />
+
+            <textarea
+                placeholder="내용을 입력하세요"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                className={styles.textarea}
+            />
+
+            <div className={styles.btnGroup}>
+                <button onClick={handleSubmitClick} className={styles.submitBtn}>수정</button>
+                <button onClick={handleCancel} className={styles.cancelBtn}>취소</button>
+            </div>
+            <Modal
+                isOpen={showModal}
+                onClose={() => setShowModal(false)}
+                onConfirm={() => {
+                    modalOnConfirm();
+                    setShowModal(false);
+                }}
+                message={modalMessage}
+                showCancelButton={showCancelButton}
+            />
+        </div>
+    );
+};
+
+export default QnaEdit;

--- a/guardians/src/pages/Community/components/BoardDetailPage.module.css
+++ b/guardians/src/pages/Community/components/BoardDetailPage.module.css
@@ -24,33 +24,60 @@
     margin-bottom: 1.5rem;
 }
 
-.backBtn {
+.actionMenuBtn{
     background: none;
     border: none;
-    color: #444;
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: 2rem;
+    color: #666;
     cursor: pointer;
-    padding-left: 0.3rem;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    outline: none;
 }
 
-.backBtn:hover {
-    text-decoration: underline;
+/* 수정/삭제 버튼 영역 */
+.actionsWrapper{
+    position: relative;
+    width: 10rem;
+    display: flex;
+    justify-content: flex-end;
 }
 
-.deleteBtn {
+/* 버튼 메뉴 */
+.actionButtons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    position: absolute;
+    top: 25px;  /* 버튼 위치를 세로 점 버튼 아래로 */
+    right: 0;    /* 부모의 오른쪽 끝에 맞추기 */
+    background-color: #fff;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.actionMenuBtn:focus {
+    outline: none;
+}
+
+.actionButtons button {
+    font-size: 1rem;
     background: none;
     border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    transition: background-color 0.3s;
+}
+.deleteBtn{
     font-size: 0.95rem;
     font-weight: 500;
-    cursor: pointer;
     padding: 0.3rem 0.8rem;
-}
 
-.deleteBtn:hover {
-    text-decoration: underline;
 }
-
 
 /* ───────────────── Header Card ───────────────── */
 .header-card {
@@ -84,72 +111,27 @@
 }
 
 /* ───────────────── Action Button (Like) ───────────────── */
-.actionMenuBtn {
-    background: none;
-    border: none;
-    font-size: 2rem;
-    color: #666;
-    cursor: pointer;
-    padding: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    outline: none;  /* 기본 포커스 테두리 제거 */
-}
-.actionMenuBtn:focus {
-    outline: none;
-}
 
-/* 수정/삭제 버튼 영역 */
-.actionsWrapper {
-    position: relative;
-    width: 10rem;
-    display: flex;
-    justify-content: flex-end;
-}
-
-/* 버튼 메뉴 */
-.actionButtons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    position: absolute;
-    top: 25px;  /* 버튼 위치를 세로 점 버튼 아래로 */
-    right: 0;    /* 부모의 오른쪽 끝에 맞추기 */
-    background-color: #fff;
-    padding: 1rem;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-}
-
-/* 포커스 시 파란색 테두리 없애기 */
-.actionMenuBtn:focus {
-    outline: none;
-}
-.actionButtons button {
+.actionButtons{
     font-size: 1rem;
-    color: #333;
-    background: none;
     border: none;
     cursor: pointer;
     padding: 0.5rem;
     transition: background-color 0.3s;
+    outline: none;
+    box-shadow: none;
 }
 
-.actionButtons button:hover {
-    background-color: #fff7ed;
-}
 
 /* 수정/삭제 버튼 토글 애니메이션 */
-.actionButtons {
+.actionButtons{
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.3s ease-in-out;
 }
 
 .actionsWrapper button:focus + .actionButtons,
-.actionsWrapper .actionButtons {
+.actionsWrapper .actionButtons{
     opacity: 1;
     pointer-events: all;
     margin-top: 1.2rem;
@@ -249,8 +231,6 @@
     color: #e07c2a;
 }
 
-/* .commentUsername 스타일은 .usernameLink가 대체하므로 제거 */
-/* .username 스타일은 .usernameLink가 대체하므로 제거 */
 
 
 .createdAt {
@@ -304,7 +284,7 @@
 }
 
 /* ───────────────── Review (Comment Actions - 동일한 용도로 통합) ───────────────── */
-.reviewActionBtns { /* commentActionBtns로 변경 고려 */
+.reviewActionBtns {
     display: flex;
     gap: 0.5rem;
     margin-top: 2rem;

--- a/guardians/src/pages/Community/components/QnaDetailPage.module.css
+++ b/guardians/src/pages/Community/components/QnaDetailPage.module.css
@@ -134,9 +134,6 @@
     padding: 0.3rem 0.8rem;
 }
 
-.deleteBtn:hover {
-    text-decoration: underline;
-}
 
 .commentSection {
     margin-top: 3rem;
@@ -278,9 +275,6 @@
     outline: none;  /* 기본 포커스 테두리 제거 */
 }
 
-.actionMenuBtn:focus {
-    outline: none;
-}
 
 /* 수정/삭제 버튼 영역 */
 .actionsWrapper {
@@ -312,7 +306,6 @@
 
 .actionButtons button {
     font-size: 1rem;
-    color: #333;
     background: none;
     border: none;
     cursor: pointer;
@@ -320,6 +313,10 @@
     transition: background-color 0.3s;
 }
 
+.actionButtons button:focus {
+    outline: none;
+    box-shadow: none;
+}
 .actionButtons button:hover {
     background-color: #fff7ed;
 }
@@ -467,4 +464,57 @@
 /* 이름에 마우스 올렸을 때 */
 .usernameLink:hover {
     color: #e07c2a;
+}
+
+.modalOverlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modalContent {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2rem;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    max-width: 400px;
+    width: 100%;
+    text-align: center;
+}
+
+.modalMessage {
+    font-size: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.modalButtons {
+    display: flex;
+    justify-content: space-around;
+}
+
+.modalButtons:focus{
+    outline:none;
+}
+
+.cancelBtn {
+    background-color: #ddd;
+    border: none;
+    padding: 0.5rem 1.2rem;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.submitBtn {
+    background-color: #ffa94d;
+    border: none;
+    padding: 0.5rem 1.2rem;
+    border-radius: 6px;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+    outline: none;
 }


### PR DESCRIPTION
## 📌 PR 제목
- feat: Add confirmation modal for board and QnA edit actions

---

## ✨ 주요 변경사항
- Board edit 페이지에 수정 시 확인 모달 추가
- QnA edit 페이지에도 동일한 확인 모달 동작 추가
- 제목, 내용 입력 안됐을 때 경고 모달 추가
- API 호출 후 정상 동작 시 커뮤니티 페이지로 이동
- 모달에서 취소 버튼 클릭 시 모달 닫기 처리
- UX 일관성을 위해 Board와 QnA 모달 동작 통일

---

## 🔍 상세 설명
- 사용자 경험(UX) 개선을 위해 수정 시 바로 저장하지 않고, 확인 모달을 띄워 의사결정을 유도하도록 구현함
- Board와 QnA 수정 시 필수 입력 값(title, content) 누락 방지 경고 모달 추가
- 모달의 확인 버튼 클릭 시 API 호출 및 페이지 이동, 취소 버튼 클릭 시 모달 닫기만 수행
- QnA와 Board 모듈 모두 유사한 UX를 제공하여 일관성 확보

---

## ✅ 확인 리스트
- [x] Board 수정 모달 정상 동작 확인
- [x] QnA 수정 모달 정상 동작 확인
- [x] 필수 입력 값 누락 시 경고 모달 정상 동작 확인
- [x] API 응답 형식 및 오류 처리 정상 동작 확인
- [x] 불필요한 콘솔 로그 및 주석 제거 확인

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 Board와 QnA API 테스트 완료
- [x] 프론트엔드에서 Board 및 QnA 수정 모달 연동 확인

---

## 📎 관련 이슈
Closes #123 (예: `Closes #123`)

---

## 💬 기타 공유사항
- QnA 및 Board 모듈의 모달 UX를 통합함으로써 유지보수성을 높임
- 후속 작업으로 삭제 모달 및 입력 검증 로직 개선 예정
