### PR TITLE
fix: 크리티컬 버그 4종 수정

### DIFF
--- a/guardians/package-lock.json
+++ b/guardians/package-lock.json
@@ -82,6 +82,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1617,6 +1618,7 @@
       "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1632,6 +1634,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1691,6 +1694,7 @@
       "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.31.1",
         "@typescript-eslint/types": "8.31.1",
@@ -1908,6 +1912,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2048,6 +2053,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2545,6 +2551,7 @@
       "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5598,6 +5605,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5640,6 +5648,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5651,10 +5660,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-<<<<<<< Updated upstream
       "license": "MIT",
-=======
->>>>>>> Stashed changes
       "peerDependencies": {
         "react": "*"
       }
@@ -6090,6 +6096,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6154,6 +6161,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6274,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6364,6 +6373,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6411,21 +6421,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/guardians/src/pages/AdminPage/DashboardPage/AdminDashboard.tsx
+++ b/guardians/src/pages/AdminPage/DashboardPage/AdminDashboard.tsx
@@ -168,7 +168,7 @@ const AdminDashboardPage: React.FC = () => {
         const areAllOthersUnhealthy = isUnhealthy(argo.status) && isUnhealthy(jenkins.status) && isUnhealthy(grafana.status);
 
         if (areAllOthersUnhealthy) {
-            if (harbor.status !== 'error') {
+            if (harbor.status !== 'Error Fetching') {
                 setServices(prev => prev.map(s =>
                     s.id === 'harbor'
                         ? { ...s, status: 'Error Fetching', details: 'System-wide failure detected.' }

--- a/guardians/src/pages/Community/BoardWrite.tsx
+++ b/guardians/src/pages/Community/BoardWrite.tsx
@@ -93,14 +93,6 @@ const BoardWrite = ({ type }: BoardWriteProps) => {
                 message={modalMessage}
                 showCancelButton={false}
             />
-            <Modal
-                isOpen={modalOpen}
-                onClose={() => setModalOpen(false)}
-                onConfirm={() => setModalOpen(false)}
-                confirmText="확인"
-                message={modalMessage}
-                showCancelButton={false}
-            />
 
             {/* 등록/취소 확인용 모달 */}
             <Modal

--- a/guardians/src/pages/Community/QnaWrite.tsx
+++ b/guardians/src/pages/Community/QnaWrite.tsx
@@ -176,15 +176,6 @@ const QnaWrite = () => {
                     setShowModal(false);
                 }}
                 message={modalMessage}
-            />
-            <Modal
-                isOpen={showModal}
-                onClose={() => setShowModal(false)}
-                onConfirm={() => {
-                    modalOnConfirm();
-                    setShowModal(false);
-                }}
-                message={modalMessage}
                 showCancelButton={showCancelButton}
             />
 

--- a/guardians/src/pages/Community/StudyBoardDetailPage.tsx
+++ b/guardians/src/pages/Community/StudyBoardDetailPage.tsx
@@ -28,6 +28,13 @@ interface Comment {
     tier?: string; // 티어 정보 추가 (필요하다면)
 }
 
+interface UserForModal {
+    id: string;
+    username: string;
+    profileImageUrl: string;
+    email: string;
+}
+
 const StudyBoardDetailPage = () => {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -47,7 +54,7 @@ const StudyBoardDetailPage = () => {
     const [infoMessage, setInfoMessage] = useState('');
 
     // 유저 정보 모달 관련 상태
-    const [userInfo, setUserInfo] = useState<null | never>(null); // 유저 정보
+    const [userInfo, setUserInfo] = useState<UserForModal | null>(null); // 유저 정보
     const [userModalOpen, setUserModalOpen] = useState(false); // 유저 정보 모달 열기 상태
 
     const [showActions, setShowActions] = useState(false);

--- a/guardians/src/pages/JobPage/JobDetailPage.tsx
+++ b/guardians/src/pages/JobPage/JobDetailPage.tsx
@@ -9,17 +9,30 @@ import employeeIcon from "../../assets/employee.png";
 import careerIcon from "../../assets/career.png";
 import calendarIcon from "../../assets/calendar.png";
 
-interface ResJobDto {
-    id: number; // API 응답의 jobId와 매핑될 필드
+interface ApiJobDto {
+    jobId: string;
     companyName: string;
     title: string;
-    description: string; // 상세 API에는 있지만, 목록 API에는 없을 수 있음
+    description?: string;
     location: string;
     employmentType: string;
     careerLevel: string;
-    salary: string;      // 상세 API에는 있지만, 목록 API에는 없을 수 있음
+    salary?: string;
     deadline: string;
-    sourceUrl?: string;  // 회사 로고 URL
+    sourceUrl?: string;
+}
+
+interface ResJobDto {
+    id: number;
+    companyName: string;
+    title: string;
+    description: string;
+    location: string;
+    employmentType: string;
+    careerLevel: string;
+    salary: string;
+    deadline: string;
+    sourceUrl?: string;
 }
 
 const JobDetailPage = () => {
@@ -40,8 +53,8 @@ const JobDetailPage = () => {
             })
             .then((res) => {
                 if (res.data && res.data.result && Array.isArray(res.data.result.data)) {
-                    const mappedJobs = res.data.result.data.map((apiJob: any) => ({
-                        id: parseInt(apiJob.jobId, 10), // jobId를 숫자로 변환하여 id로 매핑
+                    const mappedJobs = res.data.result.data.map((apiJob: ApiJobDto) => ({
+                        id: parseInt(apiJob.jobId, 10),
                         companyName: apiJob.companyName,
                         title: apiJob.title,
                         description: apiJob.description || "", // 목록 API에 없을 경우 대비


### PR DESCRIPTION
## Background

코드 리뷰 과정에서 런타임 버그 및 타입 안전성 문제 4종이 발견되었다. AdminDashboard의 useEffect는 상태 비교 문자열 불일치로 인해 잠재적 무한 루프가 발생할 수 있었고, BoardWrite·QnaWrite는 동일한 Modal 컴포넌트가 JSX에 두 번 렌더링되어 오버레이가 이중으로 쌓히는 UI 버그가 있었다. StudyBoardDetailPage의 userInfo 상태는 `null | never` 타입으로 선언되어 유저 정보가 항상 null로 고정되는 문제가 있었으며, JobDetailPage는 API 응답 전체를 `any`로 처리하고 있었다.

## Summary

각 버그를 최소 범위로 수정했다. AdminDashboard는 비교값을 실제 설정값과 일치시켜 무한 루프를 차단했고, BoardWrite·QnaWrite는 중복 Modal 블록을 제거했다. StudyBoardDetailPage는 `UserForModal` 인터페이스를 추가하고 상태 타입을 올바르게 지정했으며, JobDetailPage는 API 응답 전용 `ApiJobDto` 인터페이스를 정의해 `any` 타입을 제거했다.

## Changes

AdminDashboard의 `useEffect([services])` 내부에서 harbor 상태를 `'Error Fetching'`으로 설정하는데, 비교 조건은 `!== 'error'`로 작성되어 있었다. 두 문자열이 달라 조건이 항상 true가 되면서 setServices가 반복 호출되고 → services 참조가 바뀌고 → effect 재실행되는 무한 루프 경로가 열려 있었다. 비교값을 `'Error Fetching'`으로 수정해 동일 상태가 됐을 때 setServices를 호출하지 않도록 했다.

BoardWrite와 QnaWrite는 알림용 Modal이 완전히 동일한 props로 두 번 선언되어 있었다. BoardWrite는 첫 번째 중복 블록을 삭제했고, QnaWrite는 `showCancelButton` prop이 없는 첫 번째를 삭제하고 완전한 두 번째를 남겼다.

StudyBoardDetailPage는 `UserForModal` 인터페이스가 없이 `useState<null | never>(null)`으로 선언되어 있었다. `never`는 도달 불가능한 타입이라 이 state는 null 외의 값을 가질 수 없었다. FreeBoardDetailPage에서 사용하는 것과 동일한 `UserForModal` 인터페이스를 추가하고 타입을 `UserForModal | null`로 정정했다.

JobDetailPage는 목록 API 응답의 각 항목을 `any`로 처리했는데, API 응답 구조(`jobId`, `companyName` 등)를 나타내는 `ApiJobDto` 인터페이스를 별도로 정의하고 해당 타입으로 대체했다.

## Checklist
- [ ] AdminDashboard에서 서비스 전체 unhealthy 상태 진입/복구 시 무한 렌더링이 발생하지 않는지 확인
- [ ] BoardWrite, QnaWrite에서 Modal이 단일 오버레이로 정상 표시되는지 확인
- [ ] 스터디 게시판 상세에서 유저 프로필 클릭 시 UserInfoModal이 정상 열리는지 확인
