### PR TITLE
refactor: API 호출 중복 제거 및 네비게이션 개선

### DIFF
--- a/guardians/src/lib/api.ts
+++ b/guardians/src/lib/api.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const api = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    withCredentials: true,
+});
+
+export default api;

--- a/guardians/src/pages/Community/FreeBoardDetailPage.tsx
+++ b/guardians/src/pages/Community/FreeBoardDetailPage.tsx
@@ -1,6 +1,7 @@
 import {useState, useEffect, useRef} from 'react';
 import axios from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import UserInfoModal from './UserInfoModal.tsx';
 import Modal from './components/Modal.tsx';
 import styles from './components/BoardDetailPage.module.css';
@@ -42,8 +43,9 @@ const FreeBoardDetailPage = () => {
     const [board, setBoard] = useState<Board | null>(null);
     const [comments, setComments] = useState<Comment[]>([]);
     const [isLiked, setIsLiked] = useState(false);
-    const [isLoggedIn, setIsLoggedIn] = useState(false);
-    const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+    const { user } = useAuth();
+    const isLoggedIn = user !== null;
+    const sessionUserId = user ? String(user.id) : null;
     const [newComment, setNewComment] = useState('');
 
     const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
@@ -66,7 +68,6 @@ const FreeBoardDetailPage = () => {
         if (!id) return;
         fetchBoard();
         fetchComments();
-        checkLoginStatus();
     }, [id]);
 
     const fetchBoard = () => {
@@ -83,19 +84,6 @@ const FreeBoardDetailPage = () => {
         axios.get(`/api/boards/${id}/comments`, { withCredentials: true })
             .then(res => setComments(res.data.result.data))
             .catch(err => console.error("Failed to fetch comments:", err));
-    };
-
-    const checkLoginStatus = () => {
-        axios.get('/api/users/me', { withCredentials: true })
-            .then(res => {
-                const id = res.data.result.data.id;
-                setIsLoggedIn(true);
-                setSessionUserId(String(id));
-            })
-            .catch(() => {
-                setIsLoggedIn(false);
-                setSessionUserId(null);
-            });
     };
 
     const toggleLike = () => {

--- a/guardians/src/pages/Community/InquiryBoardDetailPage.tsx
+++ b/guardians/src/pages/Community/InquiryBoardDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import axios from 'axios';
+import { useAuth } from '../../context/AuthContext';
 import Modal from "./components/Modal.tsx"; // Modal import
 import UserInfoModal from './UserInfoModal.tsx'; // UserInfoModal import
 import styles from './components/BoardDetailPage.module.css';
@@ -42,8 +43,9 @@ const InquiryBoardDetailPage = () => {
     const [board, setBoard] = useState<Board | null>(null);
     const [comments, setComments] = useState<Comment[]>([]);
     const [isLiked, setIsLiked] = useState(false);
-    const [isLoggedIn, setIsLoggedIn] = useState(false);
-    const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+    const { user } = useAuth();
+    const isLoggedIn = user !== null;
+    const sessionUserId = user ? String(user.id) : null;
     const [newComment, setNewComment] = useState('');
 
     const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
@@ -70,7 +72,6 @@ const InquiryBoardDetailPage = () => {
         if (!id) return;
         fetchBoard();
         fetchComments();
-        checkLoginStatus();
     }, [id]);
 
     useEffect(() => {
@@ -103,19 +104,6 @@ const InquiryBoardDetailPage = () => {
         axios.get(`/api/boards/${id}/comments`, { withCredentials: true })
             .then(res => setComments(res.data.result.data))
             .catch(err => console.error("Failed to fetch comments:", err));
-    };
-
-    const checkLoginStatus = () => {
-        axios.get('/api/users/me', { withCredentials: true })
-            .then(res => {
-                const id = res.data.result.data.id;
-                setIsLoggedIn(true);
-                setSessionUserId(String(id));
-            })
-            .catch(() => {
-                setIsLoggedIn(false);
-                setSessionUserId(null);
-            });
     };
 
     const toggleLike = () => {

--- a/guardians/src/pages/Community/QnaDetailPage.tsx
+++ b/guardians/src/pages/Community/QnaDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import UserInfoModal from './UserInfoModal';
 import styles from './components/QnaDetailPage.module.css';
 import Modal from './components/Modal.tsx';
@@ -41,8 +42,9 @@ const QnaDetailPage = () => {
     const [qna, setQna] = useState<Qna | null>(null);
     const [answers, setAnswers] = useState<Answer[]>([]);
     const [newAnswer, setNewAnswer] = useState('');
-    const [sessionUserId, setSessionUserId] = useState<string | null>(null);
-    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const { user } = useAuth();
+    const isLoggedIn = user !== null;
+    const sessionUserId = user ? String(user.id) : null;
     const [editingAnswerId, setEditingAnswerId] = useState<number | null>(null);
     const [editingAnswerContent, setEditingAnswerContent] = useState('');
     const [showActions, setShowActions] = useState(false);
@@ -63,7 +65,6 @@ const QnaDetailPage = () => {
         if (!id) return;
         fetchQna();
         fetchAnswers();
-        checkLoginStatus();
     }, [id]);
 
     useEffect(() => {
@@ -93,19 +94,6 @@ const QnaDetailPage = () => {
     const fetchAnswers = async () => {
         const res = await axios.get(`/api/qna/answers/${id}`, { withCredentials: true });
         setAnswers(res.data.result.data);
-    };
-
-    const checkLoginStatus = () => {
-        axios.get('/api/users/me', { withCredentials: true })
-            .then(res => {
-                const id = res.data.result.data.id;
-                setIsLoggedIn(true);
-                setSessionUserId(String(id));
-            })
-            .catch(() => {
-                setIsLoggedIn(false);
-                setSessionUserId(null);
-            });
     };
 
     const handleDelete = () => {

--- a/guardians/src/pages/Community/StudyBoardDetailPage.tsx
+++ b/guardians/src/pages/Community/StudyBoardDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import {useEffect, useRef, useState} from 'react';
 import axios from 'axios';
+import { useAuth } from '../../context/AuthContext';
 import styles from './components/BoardDetailPage.module.css'; // BoardDetailPage.module.css 스타일 사용
 import Modal from "./components/Modal.tsx";
 import UserInfoModal from './UserInfoModal.tsx'; // 유저 정보 모달 임포트
@@ -41,8 +42,9 @@ const StudyBoardDetailPage = () => {
     const [board, setBoard] = useState<Board | null>(null);
     const [comments, setComments] = useState<Comment[]>([]);
     const [isLiked, setIsLiked] = useState(false);
-    const [isLoggedIn, setIsLoggedIn] = useState(false);
-    const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+    const { user } = useAuth();
+    const isLoggedIn = user !== null;
+    const sessionUserId = user ? String(user.id) : null;
     const [newComment, setNewComment] = useState('');
 
     const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
@@ -65,7 +67,6 @@ const StudyBoardDetailPage = () => {
         if (!id) return;
         fetchBoard();
         fetchComments();
-        checkLoginStatus();
     }, [id]);
 
     const fetchBoard = () => {
@@ -80,19 +81,6 @@ const StudyBoardDetailPage = () => {
     const fetchComments = () => {
         axios.get(`/api/boards/${id}/comments`, { withCredentials: true })
             .then(res => setComments(res.data.result.data));
-    };
-
-    const checkLoginStatus = () => {
-        axios.get('/api/users/me', { withCredentials: true })
-            .then(res => {
-                const id = res.data.result.data.id;
-                setIsLoggedIn(true);
-                setSessionUserId(String(id));
-            })
-            .catch(() => {
-                setIsLoggedIn(false);
-                setSessionUserId(null);
-            });
     };
 
     const toggleLike = () => {

--- a/guardians/src/pages/HomePage/HomeIntroSection.tsx
+++ b/guardians/src/pages/HomePage/HomeIntroSection.tsx
@@ -1,4 +1,5 @@
 import {JSX, useEffect, useRef} from "react";
+import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import dev1 from "../../assets/HJH.png";
 import dev2 from "../../assets/JH.png";
@@ -121,6 +122,7 @@ function InfiniteReviewSlider() {
 function HomeIntroSection() {
     const {user} = useAuth();
     const isLoggedIn = !!user;
+    const navigate = useNavigate();
 
     const concerns = [
         { img: dev1, alt: "user1", text: "보안? 해킹? 도대체 어떻게 시작해야 될지...", align: "left" },
@@ -322,7 +324,7 @@ function HomeIntroSection() {
                         delay: 1,
                     }}
                     onClick={() =>
-                        window.location.href = isLoggedIn ? "/dashboard" : "/signup"
+                        navigate(isLoggedIn ? "/dashboard" : "/signup")
                     }
                     style={{
                         backgroundColor: "#ffa94d",

--- a/guardians/src/pages/LoginPage/Login.tsx
+++ b/guardians/src/pages/LoginPage/Login.tsx
@@ -33,7 +33,7 @@ const Login = () => {
             );
             const userData = res.data.result.data;
             login(userData);
-            window.location.href = "/";
+            navigate("/");
         } catch (err: unknown) {
             if (axios.isAxiosError(err)) {
                 setErrorMsg(err.response?.data?.message || "로그인 실패");

--- a/guardians/src/pages/MyPage/MypageInfoCard.tsx
+++ b/guardians/src/pages/MyPage/MypageInfoCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, ChangeEvent } from "react";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import styles from "./MypagePage.module.css";
 import EditUsernameModal from "./components/EditUsernameModal";
@@ -26,6 +27,7 @@ const MypageInfoCard = () => {
 
     const { user } = useAuth();
     const userId = user?.id;
+    const navigate = useNavigate();
 
     const fetchUserInfo = useCallback(async () => {
         if (!userId) return;
@@ -192,9 +194,9 @@ const MypageInfoCard = () => {
                     onClose={() => {
                         setShowSuccessModal(false);
                         if (successMessage.includes("탈퇴")) {
-                            window.location.href = "/";
+                            navigate("/");
                         } else {
-                            window.location.reload();
+                            fetchUserInfo();
                         }
                     }}
                 />

--- a/guardians/src/pages/WargamePage/ProfileCard.tsx
+++ b/guardians/src/pages/WargamePage/ProfileCard.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 function ProfileCard() {
+    const navigate = useNavigate();
     const [info, setInfo] = useState({
         nickname: "",
         profileImageUrl: "",
@@ -109,7 +111,7 @@ function ProfileCard() {
                             fontWeight: 500,
                             cursor: "pointer",
                         }}
-                        onClick={() => (window.location.href = "/login")}
+                        onClick={() => navigate("/login")}
                     >
                         로그인하러 가기
                     </button>

--- a/guardians/src/pages/WargamePage/WargameDetailPage.tsx
+++ b/guardians/src/pages/WargamePage/WargameDetailPage.tsx
@@ -58,6 +58,7 @@ type Review = {
 
 function WargameDetailPage() {
     const {id} = useParams();
+    const navigate = useNavigate();
     const [wargame, setWargame] = useState<Wargame | null>(null);
     const [flag, setFlag] = useState("");
     const [qaList, setQaList] = useState<QuestionWithAnswers[]>([]);
@@ -397,14 +398,11 @@ function WargameDetailPage() {
     const handleCloseModal = () => {
         setIsModalOpen(false);
         if (modalResult?.message === "로그인이 되지 않았습니다. 로그인을 해주세요.") {
-            window.location.href = "/login";
+            navigate("/login");
         } else {
-            window.location.reload();
+            fetchWargame();
         }
     };
-
-    const navigate = useNavigate();
-
 
     if (!wargame) return <p style={{padding: "3rem"}}>로딩 중...</p>;
 


### PR DESCRIPTION
## Background

각 페이지가 마운트될 때마다 `/api/users/me`를 개별 호출하는 `checkLoginStatus()` 함수가 4개 페이지에 중복 존재했다. `AuthContext`는 앱 최초 로드 시 이미 동일한 API를 호출해 `user` 상태를 전역으로 관리하고 있어, 페이지 진입 시마다 추가 네트워크 요청이 발생하는 구조였다. 또한 로그인 성공, 탈퇴, 모달 닫기 등 여러 흐름에서 `window.location.href`/`window.location.reload()`를 사용해 전체 페이지 리로드가 발생하고 있었다.

## Summary

`checkLoginStatus()`를 제거하고 `useAuth()`의 `user`로 교체했다. `isLoggedIn`은 `user !== null`로, `sessionUserId`는 `String(user?.id)`로 파생된다. `window.location` 6곳을 `useNavigate()`와 상태 기반 갱신 함수로 교체해 SPA 방식의 네비게이션으로 통일했다. axios 인스턴스 기반 파일(`src/lib/api.ts`)도 추가했다.

## Changes

`checkLoginStatus()` 패턴은 FreeBoardDetailPage, StudyBoardDetailPage, InquiryBoardDetailPage, QnaDetailPage 4개 파일에 동일하게 복사되어 있었다. 각 파일에서 해당 함수와 `isLoggedIn`/`sessionUserId` state를 제거하고 `useAuth()`에서 파생 값으로 대체했다. 이로써 페이지 진입 시 `/api/users/me` 중복 호출 4회가 제거된다.

`window.location.href = "/"`(Login, MypageInfoCard)는 `navigate("/")`로 교체했다. `window.location.reload()`는 리로드의 목적에 맞는 상태 갱신 함수로 교체했다 — MypageInfoCard에서는 `fetchUserInfo()`, WargameDetailPage에서는 `fetchWargame()`을 호출한다. ProfileCard와 HomeIntroSection도 `navigate()`로 전환하고 필요한 import를 추가했다. WargameDetailPage는 함수 하단에 중복 선언된 `navigate`를 컴포넌트 최상단으로 이동했다.

`src/lib/api.ts`는 `VITE_API_BASE_URL`과 `withCredentials: true`를 공통으로 갖는 axios 인스턴스다. 이번 PR에서는 파일 생성만 하며, 기존 25개 파일의 직접 참조 교체는 후속 PR에서 진행한다.

## Checklist
- [ ] 로그인 후 홈으로 이동 시 전체 리로드 없이 SPA 전환되는지 확인
- [ ] 탈퇴 후 홈으로 이동하는지 확인
- [ ] 게시판 상세 페이지에서 작성자 본인만 수정/삭제 버튼이 보이는지 확인
- [ ] 비로그인 상태에서 댓글 입력이 비활성화되는지 확인
